### PR TITLE
when writing to /dev/stdout without specifying a source, only copy from one source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "avml"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "argh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avml"
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT"
 description = "A portable volatile memory acquisition tool"
 authors = ["avml@microsoft.com"]


### PR DESCRIPTION
If the user specifies a destination such as `/tmp/file.image` and does not specify which source to use, `avml` tries to acquire memory from the following sources: /proc/kcore, /dev/crash, and /dev/mem.

If acquiring memory from one of the sources fails part way through, avml will start over with the next source on the list until the copy completes successfully or the list is exhausted.

However, starting over when writing to `/dev/stdout` isn't possible.

As such, when the destination is `/dev/stdout`, we should try to do a bit more work when choosing a source, and bail if acquiring memory from the single source fails.