### PR TITLE
fail faster on permanent errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "bytes",
  "elf",
  "futures",
+ "http",
  "md5",
  "reqwest",
  "snap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ bytes = "1.1"
 elf = "0.0.10"
 byteorder = "1.3"
 argh = "0.1"
+http = "0.2"
 snap = "1.0"
 futures = "0.3"
 url = { version = "2.2", optional = true }


### PR DESCRIPTION
In a handful of cases (such as invalid SAS tokens), we should fail fast,
rather than retrying.