### PR TITLE
add optional upload status indicators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +52,7 @@ name = "avml"
 version = "0.6.1"
 dependencies = [
  "async-channel",
+ "atty",
  "azure_core",
  "azure_storage",
  "azure_storage_blobs",
@@ -51,6 +63,7 @@ dependencies = [
  "elf",
  "futures",
  "http",
+ "indicatif",
  "md5",
  "reqwest",
  "snap",
@@ -277,6 +290,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +346,12 @@ checksum = "4841de15dbe0e49b9b62a417589299e3be0d557e0900d36acb87e6dae47197f5"
 dependencies = [
  "byteorder 0.5.3",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -606,6 +638,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +764,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "oauth2"
@@ -868,6 +918,21 @@ checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "reqwest"
@@ -1093,6 +1158,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,4 +47,4 @@ codegen-units=1
 
 [[bin]]
 name = "avml-upload"
-required-features = ["put", "blobstore", "status"]
+required-features = ["put", "blobstore"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2021"
 default = ["put", "blobstore"]
 put = ["reqwest", "url", "tokio"]
 blobstore = ["url", "azure_core", "azure_storage", "azure_storage_blobs", "tokio", "tokio-util", "backoff", "async-channel"]
+status = ["atty", "indicatif"]
 
 [dependencies]
 bytes = "1.1"
@@ -35,6 +36,8 @@ azure_storage = { version = "0.2", default-features = false, features = ["enable
 azure_storage_blobs = { version = "0.2", default-features = false, features = ["enable_reqwest_rustls"], optional = true }
 azure_core = { version = "0.2", default-features= false, features = ["enable_reqwest_rustls"], optional = true }
 async-channel = {version="1.6", optional=true}
+atty = { version = "0.2", optional=true }
+indicatif = { version = "0.16", optional=true }
 
 [profile.release]
 opt-level="z"
@@ -44,4 +47,4 @@ codegen-units=1
 
 [[bin]]
 name = "avml-upload"
-required-features = ["put", "blobstore"]
+required-features = ["put", "blobstore", "status"]

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -12,6 +12,7 @@ cargo fmt -- --check
 cargo build --release --no-default-features --target x86_64-unknown-linux-musl --locked
 cp target/x86_64-unknown-linux-musl/release/avml target/x86_64-unknown-linux-musl/release/avml-minimal
 cargo build --release --target x86_64-unknown-linux-musl --locked
+cargo build --release --target x86_64-unknown-linux-musl --locked --bin avml-upload --features "put blobstore status"
 cargo test --release --target x86_64-unknown-linux-musl --locked
 cargo clippy -- -D clippy::pedantic -A clippy::missing_errors_doc
 strip target/x86_64-unknown-linux-musl/release/avml

--- a/src/upload/blobstore.rs
+++ b/src/upload/blobstore.rs
@@ -313,7 +313,7 @@ impl BlobUploader {
     }
 
     async fn uploaders(&self, count: usize) -> Result<()> {
-        let status = Status::new(self.size);
+        let status = Status::new(self.size.map(|x| x as u64));
 
         let uploaders: Vec<_> = (0..usize::max(1, count))
             .map(|_| {

--- a/src/upload/http.rs
+++ b/src/upload/http.rs
@@ -34,7 +34,7 @@ pub async fn put(filename: &Path, url: &Url) -> Result<(), Error> {
         .map_err(|e| Error::Io(e, filename.to_owned()))?
         .len();
 
-    let status = Status::new(Some(size as usize));
+    let status = Status::new(Some(size));
 
     let stream = FramedRead::new(file, BytesCodec::new()).inspect(move |x| {
         if let Ok(x) = x {

--- a/src/upload/http.rs
+++ b/src/upload/http.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+use crate::upload::status::Status;
+use futures::stream::StreamExt;
 use reqwest::{Body, Client, StatusCode};
 use std::path::{Path, PathBuf};
 use tokio::fs::File;
@@ -32,7 +34,14 @@ pub async fn put(filename: &Path, url: &Url) -> Result<(), Error> {
         .map_err(|e| Error::Io(e, filename.to_owned()))?
         .len();
 
-    let stream = FramedRead::new(file, BytesCodec::new());
+    let status = Status::new(Some(size as usize));
+
+    let stream = FramedRead::new(file, BytesCodec::new()).inspect(move |x| {
+        if let Ok(x) = x {
+            status.inc(x.len());
+        }
+    });
+
     let body = Body::wrap_stream(stream);
 
     let client = Client::new();
@@ -49,5 +58,6 @@ pub async fn put(filename: &Path, url: &Url) -> Result<(), Error> {
             status: res.status().as_u16(),
         });
     }
+
     Ok(())
 }

--- a/src/upload/mod.rs
+++ b/src/upload/mod.rs
@@ -6,3 +6,5 @@ pub mod blobstore;
 
 #[cfg(feature = "put")]
 pub mod http;
+
+mod status;

--- a/src/upload/status.rs
+++ b/src/upload/status.rs
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#[cfg(feature = "status")]
+#[cfg(all(feature = "status", any(feature = "blobstore", feature = "put")))]
 #[derive(Clone)]
 pub struct Status {
     bar: Option<indicatif::ProgressBar>,
-    total: Option<usize>,
+    total: Option<u64>,
 }
 
-#[cfg(feature = "status")]
+#[cfg(all(feature = "status", any(feature = "blobstore", feature = "put")))]
 impl Status {
-    pub fn new(total: Option<usize>) -> Self {
+    pub fn new(total: Option<u64>) -> Self {
         let size = total.unwrap_or(0) as u64;
         let bar = if atty::is(atty::Stream::Stdin) {
             Some(
@@ -36,14 +36,15 @@ impl Status {
     }
 }
 
-#[cfg(not(feature = "status"))]
+#[cfg(all(not(feature = "status"), any(feature = "blobstore", feature = "put")))]
 #[derive(Clone)]
 pub struct Status {}
 
-#[cfg(not(feature = "status"))]
+#[cfg(all(not(feature = "status"), any(feature = "blobstore", feature = "put")))]
 impl Status {
-    pub fn new(_total: Option<usize>) -> Self {
+    pub fn new(_total: Option<u64>) -> Self {
         Self {}
     }
+    #[allow(clippy::unused_self)]
     pub fn inc(&self, _n: usize) {}
 }

--- a/src/upload/status.rs
+++ b/src/upload/status.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#[cfg(feature = "status")]
+#[derive(Clone)]
+pub struct Status {
+    bar: Option<indicatif::ProgressBar>,
+    total: Option<usize>,
+}
+
+#[cfg(feature = "status")]
+impl Status {
+    pub fn new(total: Option<usize>) -> Self {
+        let size = total.unwrap_or(0) as u64;
+        let bar = if atty::is(atty::Stream::Stdin) {
+            Some(
+                indicatif::ProgressBar::new(size).with_style(
+                    indicatif::ProgressStyle::default_bar()
+                        .template("{bytes} ({bytes_per_sec})")
+                        .on_finish(indicatif::ProgressFinish::AtCurrentPos),
+                ),
+            )
+        } else {
+            None
+        };
+        Self { bar, total }
+    }
+
+    pub fn inc(&self, n: usize) {
+        if let Some(bar) = &self.bar {
+            bar.inc(n as u64);
+            if self.total.is_none() {
+                bar.set_length(bar.position());
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "status"))]
+#[derive(Clone)]
+pub struct Status {}
+
+#[cfg(not(feature = "status"))]
+impl Status {
+    pub fn new(_total: Option<usize>) -> Self {
+        Self {}
+    }
+    pub fn inc(&self, _n: usize) {}
+}


### PR DESCRIPTION
These are enabled at compile time using the `status` feature and are not enabled by default during builds.

Note, the build artifact `avml-upload` will include this feature.