### PR TITLE
Make /proc/kcore acquisition better

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -211,7 +211,7 @@ impl<'a, 'b> Snapshot<'a, 'b> {
         for phdr in file.phdrs {
             // Skip PT_LOAD that do not represent physical memory
             // TODO: compare to (-1)
-            if phdr.paddr == 0xffffffff || phdr.paddr == 0xffffffffffffffff {
+            if phdr.paddr == 0xffff_ffff || phdr.paddr == 0xffff_ffff_ffff_ffff {
                 continue;
             }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -205,7 +205,6 @@ impl<'a, 'b> Snapshot<'a, 'b> {
         let first_physical_address = first_memory_range.start;
         let last_memory_range = &self.memory_ranges[self.memory_ranges.len() - 1];
         let last_physical_address = last_memory_range.end + 1;
-        
         let mut found_first: bool = false;
         let mut blocks = vec![];
 


### PR DESCRIPTION
Fixes issue in PPC64 acquisition where file offset was invalid. 
Ram segments are added sequentially after the first one in the program header.
So only after finding the first physical address append blocks.
Also, this way we don't "split" some ram segments in AMD64
```
...
00100000-c61ce017 : System RAM
c61ce018-c61ddc57 : System RAM
c61ddc58-c61de017 : System RAM
c61de018-c61ee057 : System RAM
c61ee058-c6612fff : System RAM
...
```
as in the kcore file it just apears as 
```
  LOAD           0x0000177940103000 0xffff977940100000 0x0000000000100000
                 0x00000000c60ce000 0x00000000c60ce000  RWE    0x1000
  LOAD           0x0000177a061d2000 0xffff977a061cf000 0x00000000c61cf000
                 0x000000000000e000 0x000000000000e000  RWE    0x1000
  LOAD           0x0000177a061e2000 0xffff977a061df000 0x00000000c61df000
                 0x000000000000f000 0x000000000000f000  RWE    0x1000
  LOAD           0x0000177a061f2000 0xffff977a061ef000 0x00000000c61ef000
                 0x0000000000424000 0x0000000000424000  RWE    0x1000
  LOAD           0x0000177a0661d000 0xffff977a0661a000 0x00000000c661a000
                 0x0000000000445000 0x0000000000445000  RWE    0x1000
  LOAD           0x0000177a06e17000 0xffff977a06e14000 0x00000000c6e14000
                 0x000000000fd8f000 0x000000000fd8f000  RWE    0x1000
```
so they are physically aligned and easier to manage and more data is returned.
First time doing anything in rust, so correct me if I have done something incorrectly.