### PR TITLE
Update elf dependency to v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,9 +322,9 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "elf"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c09b5bbd5d4c1318fd4825d697b8117506fc36ab9680bdd792f65a2acbdf1ed"
+checksum = "6de42b0529467fc9a2692fd91585c84dd255fb15b0df0f80299724a9456986c6"
 
 [[package]]
 name = "encode_unicode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ status = ["atty", "indicatif"]
 byteorder = "1.3"
 bytes = "1.2"
 clap = {version="4.0", default-features=false, features=["derive", "std", "usage", "error-context", "help"]}
-elf = "0.6"
+elf = "0.7"
 futures = "0.3"
 http = "0.2"
 md5 = "0.7"


### PR DESCRIPTION
This is my last planned update for the elf package for time time being. There were some minor renames (gabi module -> abi, elf::File -> elf::ElfStream). I encapsulated the cached reader into the ElfStream so that users don't need to instantiate it themselves. I also made ElfStream::open_stream do a minimal parsing of the program headers up front, hence the segments() change.