### PR TITLE
update build scripts

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,5 @@
+[files]
+extend-exclude = [
+    # there are a test input files, not source code which we manage
+    "test/*.txt",
+]

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/bash
 
-set -exu
-
+set -uvex -o pipefail
 
 DEBIAN_FRONTEND=noninteractive sudo apt-get install musl-dev musl-tools musl
 
@@ -9,13 +8,16 @@ rustup component add rustfmt
 rustup target add x86_64-unknown-linux-musl
 rustup update stable
 
+cargo install typos-cli
+typos
+
 cargo fmt -- --check
+cargo clippy --locked --all-targets --all-features -- -D warnings -D clippy::pedantic -A clippy::missing_errors_doc
+cargo test --release --target x86_64-unknown-linux-musl --locked --all-targets --all-features
 cargo build --release --no-default-features --target x86_64-unknown-linux-musl --locked
 cp target/x86_64-unknown-linux-musl/release/avml target/x86_64-unknown-linux-musl/release/avml-minimal
 cargo build --release --target x86_64-unknown-linux-musl --locked
 cargo build --release --target x86_64-unknown-linux-musl --locked --bin avml-upload --features "put blobstore status"
-cargo test --release --target x86_64-unknown-linux-musl --locked
-cargo clippy --locked --all-targets --all-features -- -D warnings -D clippy::pedantic -A clippy::missing_errors_doc
 strip target/x86_64-unknown-linux-musl/release/avml
 strip target/x86_64-unknown-linux-musl/release/avml-minimal
 strip target/x86_64-unknown-linux-musl/release/avml-convert


### PR DESCRIPTION
* Adds the `typos` utility, mirroring Freta's internal development practices
* Runs tests & lints earlier in the build