### PR TITLE
group azure dependabot updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      azure-sdk:
+        patterns:
+          - "azure*"


### PR DESCRIPTION
Azure SDK dependencies need to be applied all at once.  This PR updates the dependabot config to make a single PR for all of the Azure SDK dependencies.

https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/