### PR TITLE
update minimum supported rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/microsoft/avml"
 repository = "https://github.com/microsoft/avml"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 
 [features]
 default = ["put", "blobstore", "native-tls"]


### PR DESCRIPTION
Due to dependencies requiring 1.70.0, we need to update our minimum supported rust version.