### PR TITLE
Use #[expect] instead of #[allow] for clippy lint overrides

### DIFF
--- a/src/disk_usage.rs
+++ b/src/disk_usage.rs
@@ -83,7 +83,11 @@ fn check_max_usage_percentage(
 /// `TryInto<f64> for u64` is not implemented.  This tries to be mindful of the
 /// following edge condition:
 /// 1. The value must be less than or equal to the const `EXCESSIVE_VALUE`
-#[allow(clippy::cast_precision_loss, clippy::as_conversions)]
+#[expect(
+    clippy::cast_precision_loss,
+    clippy::as_conversions,
+    reason = "value is bounded by EXCESSIVE_VALUE (4 EB) which is below f64 precision limits"
+)]
 fn u64_to_f64(value: u64) -> Result<f64> {
     if value > EXCESSIVE_VALUE {
         return Err(Error::Other(
@@ -100,10 +104,11 @@ fn u64_to_f64(value: u64) -> Result<f64> {
 /// following edge conditions:
 /// 1. The value must be a signed positive value
 /// 2. The value is explicitly truncated and clamped to the integer value
-#[allow(
+#[expect(
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,
-    clippy::as_conversions
+    clippy::as_conversions,
+    reason = "sign guarded by is_sign_positive check; truncation is explicit"
 )]
 fn f64_to_u64(value: f64) -> Result<u64> {
     if !value.is_sign_positive() {
@@ -156,7 +161,10 @@ fn disk_usage(path: &Path) -> Result<DiskUsage> {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::assertions_on_result_states)]
+    #![expect(
+        clippy::assertions_on_result_states,
+        reason = "tests intentionally assert on Result variants via is_err()"
+    )]
 
     use super::*;
 

--- a/src/iomem.rs
+++ b/src/iomem.rs
@@ -72,7 +72,10 @@ pub fn merge_ranges(mut ranges: Vec<Range<u64>>) -> Vec<Range<u64>> {
     while !ranges.is_empty() {
         let mut range = ranges.remove(0);
 
-        #[allow(clippy::indexing_slicing)]
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "ranges[0] guarded by the !ranges.is_empty() check above"
+        )]
         while !ranges.is_empty() && range.end >= ranges[0].start {
             let next = ranges.remove(0);
             range = range.start..next.end;

--- a/src/upload/blobstore.rs
+++ b/src/upload/blobstore.rs
@@ -36,20 +36,17 @@ pub enum Error {
 
 type Result<T> = core::result::Result<T, Error>;
 
-#[allow(clippy::expect_used)]
 const ONE_MB_NZ: NonZeroU64 = NonZeroU64::new(1024 * 1024).expect("ONE_MB must be non-zero");
 
 /// Maximum number of blocks
 ///
 /// <https://docs.microsoft.com/en-us/azure/storage/blobs/scalability-targets#scale-targets-for-blob-storage>
-#[allow(clippy::expect_used)]
 const BLOB_MAX_BLOCKS: NonZeroU64 =
     NonZeroU64::new(50_000).expect("blob max blocks must be non-zero");
 
 /// Maximum size of any single block
 ///
 /// <https://docs.microsoft.com/en-us/azure/storage/blobs/scalability-targets#scale-targets-for-blob-storage>
-#[allow(clippy::expect_used)]
 const BLOB_MAX_BLOCK_SIZE: NonZeroU64 = ONE_MB_NZ.saturating_mul(
     NonZeroU64::new(4000).expect("blob max block size multiplier must be non-zero"),
 );
@@ -57,14 +54,12 @@ const BLOB_MAX_BLOCK_SIZE: NonZeroU64 = ONE_MB_NZ.saturating_mul(
 /// Maximum total size of a file
 ///
 /// <https://docs.microsoft.com/en-us/azure/storage/blobs/scalability-targets#scale-targets-for-blob-storage>
-#[allow(clippy::expect_used)]
 const BLOB_MAX_FILE_SIZE: NonZeroU64 = BLOB_MAX_BLOCKS.saturating_mul(BLOB_MAX_BLOCK_SIZE);
 
 /// Minimum block size, which is required to trigger the "high-throughput block
 /// blobs" feature on all storage accounts
 ///
 /// <https://azure.microsoft.com/en-us/blog/high-throughput-with-azure-blob-storage/>
-#[allow(clippy::expect_used)]
 const BLOB_MIN_BLOCK_SIZE: NonZeroU64 = ONE_MB_NZ
     .saturating_mul(NonZeroU64::new(5).expect("blob min block size multiplier must be non-zero"));
 
@@ -74,7 +69,6 @@ const BLOB_MIN_BLOCK_SIZE: NonZeroU64 = ONE_MB_NZ
 /// VM scaleset) to a single default storage account.
 ///
 /// <https://docs.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account#scale-targets-for-standard-storage-accounts>
-#[allow(clippy::expect_used)]
 const MAX_CONCURRENCY: NonZeroUsize =
     NonZeroUsize::new(10).expect("max concurrency must be non-zero");
 
@@ -84,12 +78,10 @@ const MAX_CONCURRENCY: NonZeroUsize =
 /// VM scaleset) to a single default storage account.
 ///
 /// <https://docs.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account#scale-targets-for-standard-storage-accounts>
-#[allow(clippy::expect_used)]
 pub const DEFAULT_CONCURRENCY: NonZeroUsize =
     NonZeroUsize::new(10).expect("default concurrency must be non-zero");
 
 /// Keep at most 500MB of block data in flight across all uploaders.
-#[allow(clippy::expect_used)]
 const MEMORY_THRESHOLD: NonZeroU64 = ONE_MB_NZ
     .saturating_mul(NonZeroU64::new(500).expect("memory threshold multiplier must be non-zero"));
 

--- a/src/upload/status.rs
+++ b/src/upload/status.rs
@@ -20,7 +20,10 @@ impl Status {
         let bar = stdin().is_terminal().then(|| {
             ProgressBar::new(size)
                 .with_style(
-                    #[allow(clippy::expect_used)]
+                    #[expect(
+                        clippy::expect_used,
+                        reason = "template string is a compile-time literal known to be valid"
+                    )]
                     ProgressStyle::default_bar()
                         .template("{bytes} ({bytes_per_sec})")
                         .expect("progress bar build failed"),
@@ -56,10 +59,16 @@ impl Status {
     pub fn new(_total: Option<u64>) -> Self {
         Self {}
     }
-    #[allow(clippy::unused_self)]
+    #[expect(
+        clippy::unused_self,
+        reason = "API parity with the status-enabled variant"
+    )]
     pub fn inc(&self, _n: usize) {}
 
     #[cfg(feature = "blobstore")]
-    #[allow(clippy::unused_self)]
+    #[expect(
+        clippy::unused_self,
+        reason = "API parity with the status-enabled variant"
+    )]
     pub fn reset(&self) {}
 }


### PR DESCRIPTION
Switch the codebase's `#[allow(clippy::...)]` lint suppressions to
`#[expect(clippy::..., reason = "...")]`. `#[expect]` errors when the
underlying lint stops firing, which alerts us when a suppression has
gone stale.

Changes per file:

- `src/iomem.rs`: `indexing_slicing` on `ranges[0]` inside `merge_ranges`
  — reason notes the surrounding `!ranges.is_empty()` guard.
- `src/disk_usage.rs`: cast-precision/sign suppressions on `u64_to_f64`
  and `f64_to_u64` — reasons point at the `EXCESSIVE_VALUE` and
  `is_sign_positive` checks that make the casts safe. The test-mod
  inner `#![allow(assertions_on_result_states)]` also converted.
- `src/upload/status.rs`: `expect_used` on the static-template
  `ProgressStyle::default_bar().template(...).expect(...)` call and the
  two `unused_self` no-ops in the `status`-disabled `Status` shim.
- `src/upload/blobstore.rs`: the eight `#[allow(clippy::expect_used)]`
  attributes on `NonZero{U64,Usize}::new(N).expect(...)` constants are
  removed outright. Converting them to `#[expect]` revealed the lint
  doesn't fire in `const` context, so the suppressions were already
  dead code.

Verified with:

- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo clippy --no-default-features --all-targets -- -D warnings`
- `cargo test --all-features`
- `cargo fmt --check`