### PR TITLE
Convert tuple error variants to named-field structs

### DIFF
--- a/src/bin/avml-convert.rs
+++ b/src/bin/avml-convert.rs
@@ -18,7 +18,10 @@ use std::{
 
 fn convert(src: &Path, dst: &Path, compress: bool) -> Result<()> {
     let src_len = metadata(src)
-        .map_err(|e| image::Error::Io(e, "unable to read source size"))?
+        .map_err(|source| image::Error::Io {
+            context: "unable to read source size",
+            source,
+        })?
         .len();
     let mut image = image::Image::<File, File>::new(1, src, dst)?;
     convert_image(&mut image, src_len, compress)
@@ -31,9 +34,13 @@ where
 {
     image.version = if compress { 2 } else { 1 };
     loop {
-        let current = image.src.stream_position().map_err(|e| {
-            image::Error::Io(e, "unable to get current offset into the memory source")
-        })?;
+        let current = image
+            .src
+            .stream_position()
+            .map_err(|source| image::Error::Io {
+                context: "unable to get current offset into the memory source",
+                source,
+            })?;
         if current >= src_len {
             break;
         }
@@ -51,18 +58,23 @@ where
 {
     image.version = 1;
     loop {
-        let current = image.src.stream_position().map_err(|e| {
-            image::Error::Io(e, "unable to get the current offset into the memory source")
-        })?;
+        let current = image
+            .src
+            .stream_position()
+            .map_err(|source| image::Error::Io {
+                context: "unable to get the current offset into the memory source",
+                source,
+            })?;
         if current >= src_len {
             break;
         }
-        let current_dst = image.dst.stream_position().map_err(|e| {
-            image::Error::Io(
-                e,
-                "unable to get the current offset into the destination stream",
-            )
-        })?;
+        let current_dst = image
+            .dst
+            .stream_position()
+            .map_err(|source| image::Error::Io {
+                context: "unable to get the current offset into the destination stream",
+                source,
+            })?;
 
         let header = image.read_header()?;
         let mut zeros = vec![0; ONE_MB];
@@ -73,7 +85,10 @@ where
             image
                 .dst
                 .write_all(&zeros)
-                .map_err(|e| image::Error::Io(e, "unable to write padding bytes"))?;
+                .map_err(|source| image::Error::Io {
+                    context: "unable to write padding bytes",
+                    source,
+                })?;
             unmapped -= ONE_MB;
         }
         if unmapped > 0 {
@@ -81,7 +96,10 @@ where
             image
                 .dst
                 .write_all(&zeros)
-                .map_err(|e| image::Error::Io(e, "unable to write padding bytes"))?;
+                .map_err(|source| image::Error::Io {
+                    context: "unable to write padding bytes",
+                    source,
+                })?;
         }
 
         let size = header.size()?;
@@ -90,20 +108,27 @@ where
             1 => {
                 let mut handle =
                     (&mut image.src).take(size.try_into().map_err(image::Error::IntConversion)?);
-                copy(&mut handle, &mut image.dst)
-                    .map_err(|e| image::Error::Io(e, "unable to copy image data"))?;
+                copy(&mut handle, &mut image.dst).map_err(|source| image::Error::Io {
+                    context: "unable to copy image data",
+                    source,
+                })?;
             }
             2 => {
                 let mut decoder = FrameDecoder::new(&mut image.src)
                     .take(size.try_into().map_err(image::Error::IntConversion)?);
-                copy(&mut decoder, &mut image.dst)
-                    .map_err(|e| image::Error::Io(e, "unable to copy image data"))?;
+                copy(&mut decoder, &mut image.dst).map_err(|source| image::Error::Io {
+                    context: "unable to copy image data",
+                    source,
+                })?;
                 image
                     .src
                     .seek(SeekFrom::Current(8))
-                    .map_err(|e| image::Error::Io(e, "unable to seek past the compressed size"))?;
+                    .map_err(|source| image::Error::Io {
+                        context: "unable to seek past the compressed size",
+                        source,
+                    })?;
             }
-            _ => unimplemented!(),
+            _ => return Err(image::Error::UnimplementedVersion.into()),
         }
     }
 
@@ -112,7 +137,10 @@ where
 
 fn convert_to_raw(src: &Path, dst: &Path) -> Result<()> {
     let src_len = metadata(src)
-        .map_err(|e| image::Error::Io(e, "unable to get source file size"))?
+        .map_err(|source| image::Error::Io {
+            context: "unable to get source file size",
+            source,
+        })?
         .len();
     let mut image = image::Image::<File, File>::new(1, src, dst)?;
     convert_to_raw_image(&mut image, src_len)
@@ -141,7 +169,10 @@ where
 
 fn convert_from_raw(src: &Path, dst: &Path, compress: bool) -> Result<()> {
     let src_len = metadata(src)
-        .map_err(|e| image::Error::Io(e, "unable to read source size"))?
+        .map_err(|source| image::Error::Io {
+            context: "unable to read source size",
+            source,
+        })?
         .len();
     let mut image = image::Image::<File, File>::new(1, src, dst)?;
     encode_raw_image(&mut image, src_len, compress)

--- a/src/bin/avml-upload.rs
+++ b/src/bin/avml-upload.rs
@@ -71,7 +71,10 @@ async fn run(cmd: Cmd) -> Result<()> {
 fn main() -> Result<()> {
     let cmd = Cmd::parse();
     Runtime::new()
-        .map_err(|e| Error::Io(e, "tokio runtime error"))?
+        .map_err(|source| Error::Io {
+            context: "tokio runtime error",
+            source,
+        })?
         .block_on(run(cmd))?;
     Ok(())
 }

--- a/src/bin/avml.rs
+++ b/src/bin/avml.rs
@@ -110,7 +110,10 @@ async fn upload(config: &Config) -> Result<()> {
     if delete && config.delete {
         remove_file(&config.filename)
             .await
-            .map_err(|e| Error::Io(e, "unable to remove snapshot"))?;
+            .map_err(|source| Error::Io {
+                context: "unable to remove snapshot",
+                source,
+            })?;
     }
 
     Ok(())
@@ -132,7 +135,10 @@ fn main() -> Result<()> {
     #[cfg(any(feature = "blobstore", feature = "put"))]
     {
         Runtime::new()
-            .map_err(|e| Error::Io(e, "tokio runtime error"))?
+            .map_err(|source| Error::Io {
+                context: "tokio runtime error",
+                source,
+            })?
             .block_on(upload(&config))?;
     }
 

--- a/src/disk_usage.rs
+++ b/src/disk_usage.rs
@@ -86,10 +86,10 @@ fn check_max_usage_percentage(
 #[allow(clippy::cast_precision_loss, clippy::as_conversions)]
 fn u64_to_f64(value: u64) -> Result<f64> {
     if value > EXCESSIVE_VALUE {
-        return Err(Error::Other(
-            "unable to convert u64 to f64",
-            format!("value is too large to convert to f64: {value}"),
-        ));
+        return Err(Error::Other {
+            context: "unable to convert u64 to f64",
+            detail: format!("value is too large to convert to f64: {value}"),
+        });
     }
     Ok(value as f64)
 }
@@ -107,10 +107,10 @@ fn u64_to_f64(value: u64) -> Result<f64> {
 )]
 fn f64_to_u64(value: f64) -> Result<u64> {
     if !value.is_sign_positive() {
-        return Err(Error::Other(
-            "unable to convert f64 to u64",
-            format!("value is not a positive f64: {value}"),
-        ));
+        return Err(Error::Other {
+            context: "unable to convert f64 to u64",
+            detail: format!("value is not a positive f64: {value}"),
+        });
     }
     Ok(value.trunc() as u64)
 }
@@ -128,8 +128,10 @@ fn estimate(ranges: &[Range<u64>]) -> u64 {
 }
 
 fn disk_usage(path: &Path) -> Result<DiskUsage> {
-    let path_as_cstr = CString::new(path.as_os_str().as_bytes())
-        .map_err(|e| Error::Other("unable to convert path to CString", e.to_string()))?;
+    let path_as_cstr = CString::new(path.as_os_str().as_bytes()).map_err(|e| Error::Other {
+        context: "unable to convert path to CString",
+        detail: e.to_string(),
+    })?;
 
     // SAFETY: this is the only way to initialize the statfs64 struct
     let mut statfs: libc::statfs64 = unsafe { zeroed() };
@@ -140,10 +142,10 @@ fn disk_usage(path: &Path) -> Result<DiskUsage> {
         return Err(Error::Disk(std::io::Error::last_os_error()));
     }
 
-    let f_bsize: u64 = statfs
-        .f_bsize
-        .try_into()
-        .map_err(|e| Error::Other("unable to identify block size", format!("{e}")))?;
+    let f_bsize: u64 = statfs.f_bsize.try_into().map_err(|e| Error::Other {
+        context: "unable to identify block size",
+        detail: format!("{e}"),
+    })?;
 
     let total = statfs.f_blocks.saturating_mul(f_bsize);
     let free = statfs.f_bavail.saturating_mul(f_bsize);
@@ -164,8 +166,10 @@ mod tests {
 
     #[test]
     fn test_disk_usage() -> Result<()> {
-        let current_exe = std::env::current_exe()
-            .map_err(|e| Error::Other("unable to get current exe", e.to_string()))?;
+        let current_exe = std::env::current_exe().map_err(|e| Error::Other {
+            context: "unable to get current exe",
+            detail: e.to_string(),
+        })?;
         // check that we can get disk usage for at least one file system, here
         // we check file system that the current exe resides on
         let result = disk_usage(&current_exe)?;
@@ -213,8 +217,10 @@ mod tests {
 
     #[test]
     fn test_check_max_usable() -> Result<()> {
-        let ten = NonZeroU64::new(10)
-            .ok_or_else(|| Error::Other("unable to create NonZeroU64", String::new()))?;
+        let ten = NonZeroU64::new(10).ok_or(Error::Other {
+            context: "unable to create NonZeroU64",
+            detail: String::new(),
+        })?;
         check_max_usage(1, ten)?;
         check_max_usage(10, ten)?;
         assert!(check_max_usage(11 * 1024 * 1024, ten).is_err());

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,8 +23,12 @@ pub enum Error {
     #[error("unable to upload file to Azure Storage")]
     Blob(#[from] crate::upload::blobstore::Error),
 
-    #[error("io error: {0}")]
-    Io(#[source] IoError, &'static str),
+    #[error("io error: {context}")]
+    Io {
+        context: &'static str,
+        #[source]
+        source: IoError,
+    },
 
     #[error("no conversion required")]
     NoConversionRequired,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,16 +37,17 @@ pub enum Error {
 pub(crate) fn format_error(e: &impl StdError, f: &mut Formatter) -> FmtResult {
     write!(f, "error: {e}")?;
 
-    let mut source = e.source();
+    let Some(first) = e.source() else {
+        return Ok(());
+    };
 
-    if e.source().is_some() {
-        writeln!(f, "\ncaused by:")?;
-        let mut i: usize = 0;
-        while let Some(inner) = source {
-            writeln!(f, "{i: >5}: {inner}")?;
-            source = inner.source();
-            i = i.saturating_add(1);
-        }
+    writeln!(f, "\ncaused by:")?;
+    let mut source: Option<&dyn StdError> = Some(first);
+    let mut i: usize = 0;
+    while let Some(inner) = source {
+        writeln!(f, "{i: >5}: {inner}")?;
+        source = inner.source();
+        i = i.saturating_add(1);
     }
 
     Ok(())

--- a/src/image.rs
+++ b/src/image.rs
@@ -17,8 +17,12 @@ use std::{
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("io error: {1}")]
-    Io(#[source] std::io::Error, &'static str),
+    #[error("io error: {context}")]
+    Io {
+        context: &'static str,
+        #[source]
+        source: std::io::Error,
+    },
 
     #[error("invalid padding")]
     InvalidPadding,
@@ -68,23 +72,30 @@ impl Header {
     /// - The magic number or version is invalid
     /// - The padding value is not zero
     pub fn read<R: Read>(mut src: R) -> Result<Self> {
-        let magic = src
-            .read_u32::<LittleEndian>()
-            .map_err(|e| Error::Io(e, "unable to read header magic"))?;
-        let version = src
-            .read_u32::<LittleEndian>()
-            .map_err(|e| Error::Io(e, "unable to read header version"))?;
-        let start = src
-            .read_u64::<LittleEndian>()
-            .map_err(|e| Error::Io(e, "unable to read header start offset"))?;
+        let magic = src.read_u32::<LittleEndian>().map_err(|source| Error::Io {
+            context: "unable to read header magic",
+            source,
+        })?;
+        let version = src.read_u32::<LittleEndian>().map_err(|source| Error::Io {
+            context: "unable to read header version",
+            source,
+        })?;
+        let start = src.read_u64::<LittleEndian>().map_err(|source| Error::Io {
+            context: "unable to read header start offset",
+            source,
+        })?;
         let end = src
             .read_u64::<LittleEndian>()
-            .map_err(|e| Error::Io(e, "unable to read header end offset"))?
+            .map_err(|source| Error::Io {
+                context: "unable to read header end offset",
+                source,
+            })?
             .checked_add(1)
             .ok_or(Error::TooLarge)?;
-        let padding = src
-            .read_u64::<LittleEndian>()
-            .map_err(|e| Error::Io(e, "unable to read header padding"))?;
+        let padding = src.read_u64::<LittleEndian>().map_err(|source| Error::Io {
+            context: "unable to read header padding",
+            source,
+        })?;
         if padding != 0 {
             return Err(Error::InvalidPadding);
         }
@@ -124,8 +135,10 @@ impl Header {
         W: Write,
     {
         let bytes = self.encode()?;
-        dst.write_all(&bytes)
-            .map_err(|e| Error::Io(e, "unable to write header"))?;
+        dst.write_all(&bytes).map_err(|source| Error::Io {
+            context: "unable to write header",
+            source,
+        })?;
         Ok(())
     }
 
@@ -151,23 +164,33 @@ where
     if align_src {
         let mut buf = vec![0; PAGE_SIZE];
         while size >= PAGE_SIZE {
-            src.read_exact(&mut buf)
-                .map_err(|e| Error::Io(e, "unable to read memory page"))?;
-            dst.write_all(&buf)
-                .map_err(|e| Error::Io(e, "unable to write memory page"))?;
+            src.read_exact(&mut buf).map_err(|source| Error::Io {
+                context: "unable to read memory page",
+                source,
+            })?;
+            dst.write_all(&buf).map_err(|source| Error::Io {
+                context: "unable to write memory page",
+                source,
+            })?;
             size = size.saturating_sub(PAGE_SIZE);
         }
         if size > 0 {
             buf.resize(size, 0);
-            src.read_exact(&mut buf)
-                .map_err(|e| Error::Io(e, "unable to read memory page"))?;
-            dst.write_all(&buf)
-                .map_err(|e| Error::Io(e, "unable to write memory page"))?;
+            src.read_exact(&mut buf).map_err(|source| Error::Io {
+                context: "unable to read memory page",
+                source,
+            })?;
+            dst.write_all(&buf).map_err(|source| Error::Io {
+                context: "unable to write memory page",
+                source,
+            })?;
         }
     } else {
         let mut src = src.take(size.try_into()?);
-        std::io::copy(&mut src, &mut dst)
-            .map_err(|e| Error::Io(e, "unable to copy memory pages"))?;
+        std::io::copy(&mut src, &mut dst).map_err(|source| Error::Io {
+            context: "unable to copy memory pages",
+            source,
+        })?;
     }
     Ok(())
 }
@@ -187,7 +210,10 @@ impl<R: Read + Seek, W: Write> Image<R, W> {
             .create(true)
             .truncate(true)
             .open(path)
-            .map_err(|e| Error::Io(e, "unable to create snapshot file"))
+            .map_err(|source| Error::Io {
+                context: "unable to create snapshot file",
+                source,
+            })
     }
 
     #[cfg(target_family = "unix")]
@@ -199,7 +225,10 @@ impl<R: Read + Seek, W: Write> Image<R, W> {
             .create(true)
             .truncate(true)
             .open(path)
-            .map_err(|e| Error::Io(e, "unable to create snapshot file"))
+            .map_err(|source| Error::Io {
+                context: "unable to create snapshot file",
+                source,
+            })
     }
 
     /// Creates a new Image with the specified version, source filename, and destination filename.
@@ -213,8 +242,10 @@ impl<R: Read + Seek, W: Write> Image<R, W> {
         src_filename: &Path,
         dst_filename: &Path,
     ) -> Result<Image<File, File>> {
-        let src_filename =
-            canonicalize(src_filename).map_err(|e| Error::Io(e, "unable to canonicalize path"))?;
+        let src_filename = canonicalize(src_filename).map_err(|source| Error::Io {
+            context: "unable to canonicalize path",
+            source,
+        })?;
         let align_src = [
             Path::new("/dev/crash"),
             Path::new("/dev/mem"),
@@ -225,7 +256,10 @@ impl<R: Read + Seek, W: Write> Image<R, W> {
         let src = OpenOptions::new()
             .read(true)
             .open(&src_filename)
-            .map_err(|e| Error::Io(e, "unable to open memory source"))?;
+            .map_err(|source| Error::Io {
+                context: "unable to open memory source",
+                source,
+            })?;
 
         let dst = Self::open_dst(dst_filename)?;
 
@@ -253,7 +287,10 @@ impl<R: Read + Seek, W: Write> Image<R, W> {
         if block.offset > 0 {
             self.src
                 .seek(SeekFrom::Start(block.offset))
-                .map_err(|e| Error::Io(e, "unable to see to page"))?;
+                .map_err(|source| Error::Io {
+                    context: "unable to see to page",
+                    source,
+                })?;
         }
 
         self.copy_block(block.range.clone())?;
@@ -321,9 +358,10 @@ impl<R: Read + Seek, W: Write> Image<R, W> {
         } else {
             let mut encoder = SnapCountWriter::new(&mut self.dst);
             copy(size, self.align_src, &mut self.src, &mut encoder)?;
-            encoder
-                .finalize()
-                .map_err(|e| Error::Io(e, "unable to finalize compressed block"))?;
+            encoder.finalize().map_err(|source| Error::Io {
+                context: "unable to finalize compressed block",
+                source,
+            })?;
         }
         Ok(())
     }
@@ -344,17 +382,20 @@ impl<R: Read + Seek, W: Write> Image<R, W> {
 
         self.write_header(range.clone())?;
         if self.version == 1 {
-            self.dst
-                .write_all(&buf)
-                .map_err(|e| Error::Io(e, "unable to write non-zero block"))?;
+            self.dst.write_all(&buf).map_err(|source| Error::Io {
+                context: "unable to write non-zero block",
+                source,
+            })?;
         } else {
             let mut encoder = SnapCountWriter::new(&mut self.dst);
-            encoder
-                .write_all(&buf)
-                .map_err(|e| Error::Io(e, "unable to write compressed block"))?;
-            encoder
-                .finalize()
-                .map_err(|e| Error::Io(e, "unable to finalize compressed block"))?;
+            encoder.write_all(&buf).map_err(|source| Error::Io {
+                context: "unable to write compressed block",
+                source,
+            })?;
+            encoder.finalize().map_err(|source| Error::Io {
+                context: "unable to finalize compressed block",
+                source,
+            })?;
         }
         Ok(())
     }
@@ -370,14 +411,19 @@ impl<R: Read + Seek, W: Write> Image<R, W> {
                 {
                     let size = range_len(header.range.clone());
                     let mut decoder = FrameDecoder::new(&mut self.src).take(size);
-                    std::io::copy(&mut decoder, &mut self.dst)
-                        .map_err(|e| Error::Io(e, "unable to copy compressed data"))?;
+                    std::io::copy(&mut decoder, &mut self.dst).map_err(|source| Error::Io {
+                        context: "unable to copy compressed data",
+                        source,
+                    })?;
                 }
                 self.src
                     .seek(SeekFrom::Current(8))
-                    .map_err(|e| Error::Io(e, "unable to seek passed compressed len"))?;
+                    .map_err(|source| Error::Io {
+                        context: "unable to seek passed compressed len",
+                        source,
+                    })?;
             }
-            _ => unimplemented!(),
+            _ => return Err(Error::UnimplementedVersion),
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,11 +46,3 @@ pub use crate::{
 pub const ONE_MB: usize = 1024 * 1024;
 
 pub type Result<T> = core::result::Result<T, crate::errors::Error>;
-
-pub(crate) fn indent<T: AsRef<str>>(data: T, indent: usize) -> String {
-    data.as_ref()
-        .split('\n')
-        .map(|line| format!("{:indent$}{line}", ""))
-        .collect::<Vec<_>>()
-        .join("\n")
-}

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -41,14 +41,47 @@ pub enum Error {
     #[error("unable to create memory snapshot from source: {1}")]
     UnableToCreateSnapshotFromSource(#[source] Box<Error>, Source),
 
-    #[error("unable to create memory snapshot: {0}")]
-    UnableToCreateSnapshot(String),
+    #[error("no memory source available")]
+    NoSourceAvailable,
 
-    #[error("{0}: {1}")]
-    Other(&'static str, String),
+    #[error(
+        "all memory sources failed:\n{}",
+        fmt_all_sources(crash, kcore, devmem)
+    )]
+    AllSourcesFailed {
+        crash: Box<Error>,
+        kcore: Box<Error>,
+        devmem: Box<Error>,
+    },
+
+    #[error("unable to parse /proc/kcore: {0}")]
+    KcoreParse(&'static str),
+
+    #[error("{context}: {detail}")]
+    Other {
+        context: &'static str,
+        detail: String,
+    },
 
     #[error("disk error")]
     Disk(#[source] std::io::Error),
+}
+
+fn fmt_all_sources(crash: &Error, kcore: &Error, devmem: &Error) -> String {
+    use core::error::Error as _;
+    use core::fmt::Write as _;
+    let mut buf = String::new();
+    for (name, err) in [("crash", crash), ("kcore", kcore), ("devmem", devmem)] {
+        let _ = writeln!(buf, "  {name}: {err}");
+        let mut source: Option<&dyn core::error::Error> = err.source();
+        let mut depth = 4_usize;
+        while let Some(s) = source {
+            let _ = writeln!(buf, "{:depth$}caused by: {s}", "");
+            source = s.source();
+            depth = depth.saturating_add(2);
+        }
+    }
+    buf.trim_end().to_string()
 }
 
 impl FmtDebug for Error {
@@ -125,8 +158,8 @@ fn is_kcore_ok() -> bool {
         && can_open(Path::new("/proc/kcore"))
 }
 
-// try to perform an action, either returning on success, or having the result
-// of the error in an indented string.
+// try to perform an action, either returning on success, or yielding the error
+// to the caller for aggregation.
 //
 // This special cases `DiskUsageEstimateExceeded` errors, as we want this to
 // fail fast and bail out of the `try_method` caller.
@@ -140,7 +173,7 @@ macro_rules! try_method {
                         return Err(err);
                     }
                 }
-                crate::indent(format!("{:?}", err), 4)
+                Box::new(err)
             }
         }
     }};
@@ -237,18 +270,18 @@ impl<'a, 'b> Snapshot<'a, 'b> {
             } else if can_open(Path::new("/dev/mem")) {
                 self.create_source(&Source::DevMem)?;
             } else {
-                return Err(Error::UnableToCreateSnapshot(
-                    "no source available".to_string(),
-                ));
+                return Err(Error::NoSourceAvailable);
             }
         } else {
-            let crash_err = try_method!(self.create_source(&Source::DevCrash));
-            let kcore_err = try_method!(self.create_source(&Source::ProcKcore));
-            let devmem_err = try_method!(self.create_source(&Source::DevMem));
+            let crash = try_method!(self.create_source(&Source::DevCrash));
+            let kcore = try_method!(self.create_source(&Source::ProcKcore));
+            let devmem = try_method!(self.create_source(&Source::DevMem));
 
-            let reason = [String::new(), crash_err, kcore_err, devmem_err].join("\n");
-
-            return Err(Error::UnableToCreateSnapshot(crate::indent(reason, 4)));
+            return Err(Error::AllSourcesFailed {
+                crash,
+                kcore,
+                devmem,
+            });
         }
 
         Ok(())
@@ -322,10 +355,10 @@ impl<'a, 'b> Snapshot<'a, 'b> {
     #[cfg(not(target_family = "unix"))]
     fn check_disk_usage<R: Read + Seek, W: Write>(&self, _: &Image<R, W>) -> Result<()> {
         if self.max_disk_usage.is_some() || self.max_disk_usage_percentage.is_some() {
-            return Err(Error::Other(
-                "unable to check disk usage on this platform",
-                format!("os:{OS}"),
-            ));
+            return Err(Error::Other {
+                context: "unable to check disk usage on this platform",
+                detail: format!("os:{OS}"),
+            });
         }
         Ok(())
     }
@@ -350,24 +383,25 @@ impl<'a, 'b> Snapshot<'a, 'b> {
 
         let first_vaddr = segments
             .first()
-            .ok_or_else(|| Error::UnableToCreateSnapshot("no initial addresses".to_string()))?
+            .ok_or(Error::KcoreParse("no initial addresses"))?
             .p_vaddr;
         let first_start = self
             .memory_ranges
             .first()
-            .ok_or_else(|| Error::UnableToCreateSnapshot("no initial memory range".to_string()))?
+            .ok_or(Error::KcoreParse("no initial memory range"))?
             .start;
         let start = first_vaddr.saturating_sub(first_start);
 
         let mut physical_ranges = vec![];
 
         for phdr in segments {
-            let entry_start = phdr.p_vaddr.checked_sub(start).ok_or_else(|| {
-                Error::UnableToCreateSnapshot("unable to calculate start address".to_string())
-            })?;
-            let entry_end = entry_start.checked_add(phdr.p_memsz).ok_or_else(|| {
-                Error::UnableToCreateSnapshot("unable to calculate end address".to_string())
-            })?;
+            let entry_start = phdr
+                .p_vaddr
+                .checked_sub(start)
+                .ok_or(Error::KcoreParse("unable to calculate start address"))?;
+            let entry_end = entry_start
+                .checked_add(phdr.p_memsz)
+                .ok_or(Error::KcoreParse("unable to calculate end address"))?;
 
             physical_ranges.push(Block {
                 range: entry_start..entry_end,

--- a/src/upload/http.rs
+++ b/src/upload/http.rs
@@ -11,8 +11,12 @@ use url::Url;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("error reading file: {1}")]
-    Io(#[source] std::io::Error, PathBuf),
+    #[error("error reading file {path:?}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 
     #[error("HTTP request error")]
     Request(#[from] reqwest::Error),
@@ -30,14 +34,18 @@ pub enum Error {
 /// - The server returns an unexpected status code
 #[cfg(feature = "put")]
 pub async fn put(filename: &Path, url: &Url) -> Result<(), Error> {
-    let file = File::open(&filename)
-        .await
-        .map_err(|e| Error::Io(e, filename.to_owned()))?;
+    let file = File::open(&filename).await.map_err(|source| Error::Io {
+        path: filename.to_owned(),
+        source,
+    })?;
 
     let size = file
         .metadata()
         .await
-        .map_err(|e| Error::Io(e, filename.to_owned()))?
+        .map_err(|source| Error::Io {
+            path: filename.to_owned(),
+            source,
+        })?
         .len();
 
     let status = Status::new(Some(size));


### PR DESCRIPTION
Three related error-handling cleanups:

1. Replace positional-tuple `Io(io::Error, &'static str)` and
   `Other(&'static str, String)` variants with named-field structs
   across `avml::Error`, `image::Error`, `snapshot::Error`, and
   `upload::http::Error`. Named fields give better `Display` output,
   make pattern-matching at call sites readable, and let structured
   logging consume the fields directly.

2. Split `snapshot::Error::UnableToCreateSnapshot(String)` — which was
   doing three unrelated jobs via stringly-typed payloads — into:
   - `NoSourceAvailable` for the stdout-with-no-source path,
   - `AllSourcesFailed { crash, kcore, devmem }` carrying the three
     boxed source errors so the `#[source]` chain is preserved instead
     of flattened into an indented string, and
   - `KcoreParse(&'static str)` for the kcore ELF parse failures.
   Display for `AllSourcesFailed` walks each error's source chain so
   the user still sees the full diagnostic.

3. Replace `unimplemented!()` in `image::Image::convert_block` and
   `avml-convert::convert_to_raw_image` with
   `image::Error::UnimplementedVersion`. The version byte comes from
   a file header on disk, so a malformed input previously panicked.

The now-unused `avml::indent` helper is removed.

Verified with:

- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo clippy --no-default-features --all-targets -- -D warnings`
- `cargo test --all-features`
- `cargo fmt --check`