### PR TITLE
Rewrite merge_ranges as a linear fold

### DIFF
--- a/src/iomem.rs
+++ b/src/iomem.rs
@@ -66,21 +66,17 @@ fn parse_file(path: &Path) -> Result<Vec<Range<u64>>, Error> {
 
 #[must_use]
 pub fn merge_ranges(mut ranges: Vec<Range<u64>>) -> Vec<Range<u64>> {
-    let mut result = vec![];
     ranges.sort_unstable_by_key(|r| r.start);
 
-    while !ranges.is_empty() {
-        let mut range = ranges.remove(0);
-
-        #[allow(clippy::indexing_slicing)]
-        while !ranges.is_empty() && range.end >= ranges[0].start {
-            let next = ranges.remove(0);
-            range = range.start..next.end;
+    let mut result: Vec<Range<u64>> = Vec::with_capacity(ranges.len());
+    for range in ranges {
+        match result.last_mut() {
+            Some(last) if last.end >= range.start => {
+                last.end = last.end.max(range.end);
+            }
+            _ => result.push(range),
         }
-
-        result.push(range);
     }
-
     result
 }
 


### PR DESCRIPTION
The previous implementation used `Vec::remove(0)` inside a nested loop
on the input vector, giving it O(n²) shape on already-sorted ranges.
Replace it with the standard interval-merge fold: sort, then for each
range either extend the last entry in the result or push a new one.

Side effects:

- Drops the `#[allow(clippy::indexing_slicing)]` suppression on
  `ranges[0]`; no more indexing.
- Uses `last.end.max(range.end)` instead of overwriting with the next
  range's end. The old code lost the larger end when one range fully
  contained another (e.g. `[0..10, 1..5]` would have merged to `0..5`).
  `/proc/iomem` doesn't produce containing ranges, so the existing
  snapshot tests still pass unchanged; this is just the correct merge
  semantic.

Verified with:

- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features`
- `cargo fmt --check`