### PR TITLE
Emit kcore intersections that straddle PT_LOAD gaps

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -257,6 +257,12 @@ impl<'a, 'b> Snapshot<'a, 'b> {
     // given a set of ranges from iomem and a set of Blocks derived from the
     // pseudo-elf phys section headers, derive a set of ranges that can be used
     // to create a snapshot.
+    //
+    // Both `ranges` and `headers` must be sorted ascending and non-overlapping.
+    // For every header that overlaps a range, the intersection is emitted as a
+    // Block whose `offset` points at the corresponding position inside the
+    // kcore source. Sections of `range` that fall in gaps between PT_LOAD
+    // segments are skipped -- those addresses are not readable via kcore.
     fn find_kcore_blocks(ranges: &[Range<u64>], headers: &[Block]) -> Vec<Block> {
         let mut result = vec![];
 
@@ -264,38 +270,31 @@ impl<'a, 'b> Snapshot<'a, 'b> {
             let mut range = range.clone();
 
             for header in headers {
-                match (
-                    header.range.contains(&range.start),
-                    // TODO: ranges is currently inclusive, but not a
-                    // RangeInclusive.  this should be adjusted.
-                    header.range.contains(&(range.end.saturating_sub(1))),
-                ) {
-                    (true, true) => {
-                        let block = Block {
-                            offset: header
-                                .offset
-                                .saturating_add(range.start)
-                                .saturating_sub(header.range.start),
-                            range: range.clone(),
-                        };
-
-                        result.push(block);
-                        continue 'outer;
-                    }
-                    (true, false) => {
-                        let block = Block {
-                            offset: header
-                                .offset
-                                .saturating_add(range.start)
-                                .saturating_sub(header.range.start),
-                            range: range.start..header.range.end,
-                        };
-
-                        result.push(block);
-                        range.start = header.range.end;
-                    }
-                    _ => {}
+                // headers are sorted: once one starts past the remaining range,
+                // no later header can intersect it either.
+                if range.end <= header.range.start {
+                    continue 'outer;
                 }
+                // range starts after this header; try the next.
+                if range.start >= header.range.end {
+                    continue;
+                }
+
+                // overlap. emit the intersection.
+                let intersect_start = range.start.max(header.range.start);
+                let intersect_end = range.end.min(header.range.end);
+                result.push(Block {
+                    offset: header
+                        .offset
+                        .saturating_add(intersect_start)
+                        .saturating_sub(header.range.start),
+                    range: intersect_start..intersect_end,
+                });
+
+                if range.end <= header.range.end {
+                    continue 'outer;
+                }
+                range.start = header.range.end;
             }
         }
 
@@ -453,5 +452,72 @@ mod tests {
         let result = Snapshot::find_kcore_blocks(&ranges, &core_ranges);
 
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn translate_ranges_with_straddled_gap() {
+        // iomem range straddles a gap between two PT_LOAD segments. The
+        // slice inside the second segment must still be emitted.
+        let ranges = [Range {
+            start: 400_u64,
+            end: 900,
+        }];
+        let core_ranges = [
+            Block {
+                range: 100..500,
+                offset: 0,
+            },
+            Block {
+                range: 600..1000,
+                offset: 400,
+            },
+        ];
+
+        let expected = vec![
+            Block {
+                offset: 300,
+                range: 400..500,
+            },
+            Block {
+                offset: 400,
+                range: 600..900,
+            },
+        ];
+
+        assert_eq!(Snapshot::find_kcore_blocks(&ranges, &core_ranges), expected);
+    }
+
+    #[test]
+    fn translate_ranges_with_range_spanning_header() {
+        // iomem range fully contains a PT_LOAD segment and extends past it.
+        // Both the spanned-header slice and the post-header overlap must
+        // be emitted.
+        let ranges = [Range {
+            start: 0_u64,
+            end: 1500,
+        }];
+        let core_ranges = [
+            Block {
+                range: 100..500,
+                offset: 0,
+            },
+            Block {
+                range: 1000..2000,
+                offset: 400,
+            },
+        ];
+
+        let expected = vec![
+            Block {
+                offset: 0,
+                range: 100..500,
+            },
+            Block {
+                offset: 400,
+                range: 1000..1500,
+            },
+        ];
+
+        assert_eq!(Snapshot::find_kcore_blocks(&ranges, &core_ranges), expected);
     }
 }


### PR DESCRIPTION
`find_kcore_blocks` walks each iomem System RAM range against the
sorted PT_LOAD blocks from /proc/kcore and emits the overlapping
slices, translated to kcore file offsets. The previous match-based
implementation handled `(contains(start), contains(end-1))` only for
the `(true, true)` and `(true, false)` arms. The `(false, true)` and
`(false, false)` arms silently fell through to `_ => {}`.

That is wrong whenever an iomem range straddles a gap between two
PT_LOAD segments. Example:

    iomem   = [400..900]
    PT_LOAD = [100..500, 600..1000]

The old code emitted only `400..500` (from the first segment) and
then dropped the `600..899` slice (which `(false, true)` matched
against the second segment). For a memory-acquisition tool this is
silent data loss.

Rewrite the inner loop using the standard interval-intersection: skip
the header when it lies entirely before/after the remaining range,
otherwise emit `max(starts)..min(ends)` and advance. The four
original sub-cases collapse into one expression that is obviously
correct, and the `_ => {}` swallow goes away.

Verified with two new regression tests:

- `translate_ranges_with_straddled_gap` covers the example above.
- `translate_ranges_with_range_spanning_header` covers an iomem
  range that fully contains an early PT_LOAD and extends past it.

The existing `translate_ranges` test continues to pass; traced by
hand and emits the same four blocks as before.

Verified with:

- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo clippy --no-default-features --all-targets -- -D warnings`
- `cargo test --all-features`
- `cargo fmt --check`