### PR TITLE
Resolve iomem test fixtures via CARGO_MANIFEST_DIR

### DIFF
--- a/src/iomem.rs
+++ b/src/iomem.rs
@@ -112,6 +112,7 @@ pub fn split_ranges(ranges: Vec<Range<u64>>, max_size: u64) -> Vec<Range<u64>> {
 mod tests {
     use super::*;
     use insta::assert_json_snapshot;
+    use std::path::PathBuf;
 
     #[test]
     fn test_merge_ranges() {
@@ -128,9 +129,10 @@ mod tests {
 
     #[test]
     fn test_parse_iomem() -> Result<(), Error> {
+        let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test");
         for (filename, expected) in [
             (
-                Path::new("test/iomem.txt"),
+                "iomem.txt",
                 vec![
                     4096..654_335,
                     1_048_576..1_073_676_287,
@@ -138,7 +140,7 @@ mod tests {
                 ],
             ),
             (
-                Path::new("test/iomem-2.txt"),
+                "iomem-2.txt",
                 vec![
                     4096..655_359,
                     1_048_576..1_055_838_207,
@@ -148,7 +150,7 @@ mod tests {
                 ],
             ),
             (
-                Path::new("test/iomem-3.txt"),
+                "iomem-3.txt",
                 vec![
                     65_536..649_215,
                     1_048_576..2_146_303_999,
@@ -156,7 +158,7 @@ mod tests {
                 ],
             ),
             (
-                Path::new("test/iomem-4.txt"),
+                "iomem-4.txt",
                 vec![
                     4_096..655_359,
                     1_048_576..1_423_523_839,
@@ -168,7 +170,7 @@ mod tests {
                 ],
             ),
             (
-                Path::new("test/iomem-5.txt"),
+                "iomem-5.txt",
                 vec![
                     4_096..655_359,
                     1_048_576..175_058_967,
@@ -190,7 +192,7 @@ mod tests {
                 ],
             ),
         ] {
-            let ranges = parse_file(filename)?;
+            let ranges = parse_file(&fixtures.join(filename))?;
             assert_eq!(ranges, expected);
         }
 


### PR DESCRIPTION
`test_parse_iomem` opened fixture files with relative paths like
`Path::new("test/iomem.txt")`. That only resolves when the test binary
is invoked with `cargo test`'s default cwd (the manifest directory).
Running from any other cwd (e.g. `cargo test --manifest-path ...` from
`/tmp`) produced a confusing "No such file" failure.

Anchor the fixture lookup to `env!("CARGO_MANIFEST_DIR")` so the
absolute path is baked in at compile time, and pull the per-case
relative names out to the bottom of each tuple so they read as data.

Verified by running the test from `/tmp` against the absolute manifest
path; previously failed, now passes.

Verified with:

- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features`
- `cargo fmt --check`
- `cd /tmp && cargo test --manifest-path .../Cargo.toml --all-features iomem::tests::test_parse_iomem`