### PR TITLE
Document what MAX_BLOCK_SIZE controls

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -41,6 +41,14 @@ pub enum Error {
 
 type Result<T> = core::result::Result<T, Error>;
 
+/// Largest block AVML emits in a single header. Ranges larger than this
+/// are split into `MAX_BLOCK_SIZE`-sized chunks before being written.
+///
+/// Blocks at or below this threshold are buffered fully in memory so
+/// all-zero blocks can be elided (`copy_if_nonzero`); larger blocks
+/// stream straight through without zero-elision. So this constant also
+/// caps the per-block buffer allocation (currently 16 MiB) and sets
+/// the granularity at which zero regions are skipped.
 pub const MAX_BLOCK_SIZE: u64 = 0x1000 * 0x1000;
 const PAGE_SIZE: usize = 0x1000;
 const HEADER_LEN: usize = 32;


### PR DESCRIPTION
The constant has been a bare `0x1000 * 0x1000` since it was introduced
in #45, with no comment explaining its role. It controls three
behaviors that are not obvious from the name alone:

- the maximum block emitted in a single v2 header (larger ranges are
  chunked into `MAX_BLOCK_SIZE` pieces),
- whether a block is buffered for zero-elision or streamed through
  without it, and
- the upper bound on the in-memory buffer used by `copy_if_nonzero`.

Add a doc comment spelling those out so future modifiers know what
shifts when the value changes.