### PR TITLE
Hoist clippy lint config into Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,25 @@ url = {version="2.5", optional=true, default-features=false}
 insta = {version="1.47", features=["json"]}
 rand = {version="0.10", default-features=false, features=["std_rng"]}
 
+[lints.clippy]
+arithmetic_side_effects = "warn"
+as_conversions = "warn"
+assertions_on_result_states = "warn"
+expect_used = "deny"
+if_then_some_else_none = "deny"
+indexing_slicing = "deny"
+manual_assert = "deny"
+needless_continue = "warn"
+panic = "deny"
+pattern_type_mismatch = "warn"
+redundant_pub_crate = "deny"
+shadow_unrelated = "deny"
+std_instead_of_core = "deny"
+undocumented_unsafe_blocks = "deny"
+unused_trait_names = "warn"
+unwrap_used = "deny"
+verbose_file_reads = "warn"
+
 [profile.release]
 opt-level="z"
 lto=true

--- a/src/bin/avml-convert.rs
+++ b/src/bin/avml-convert.rs
@@ -1,12 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#![deny(clippy::unwrap_used)]
-#![deny(clippy::expect_used)]
-#![deny(clippy::panic)]
-#![deny(clippy::manual_assert)]
-#![deny(clippy::indexing_slicing)]
-
 use avml::{Error, ONE_MB, Result, image};
 use clap::{Parser, ValueEnum};
 use snap::read::FrameDecoder;
@@ -67,14 +61,14 @@ where
         let header = image.read_header()?;
         let mut zeros = vec![0; ONE_MB];
 
-        let mut unmapped = usize::try_from(header.range.start - current_dst)
+        let mut unmapped = usize::try_from(header.range.start.saturating_sub(current_dst))
             .map_err(image::Error::IntConversion)?;
         while unmapped > ONE_MB {
             image
                 .dst
                 .write_all(&zeros)
                 .map_err(|e| image::Error::Io(e, "unable to write padding bytes"))?;
-            unmapped -= ONE_MB;
+            unmapped = unmapped.saturating_sub(ONE_MB);
         }
         if unmapped > 0 {
             zeros.resize(unmapped, 0);
@@ -195,7 +189,7 @@ fn main() -> Result<()> {
 mod tests {
     use crate::{convert_image, convert_to_raw_image, encode_raw_image};
     use avml::{Result, image};
-    use rand::{Rng, SeedableRng, rngs::SmallRng};
+    use rand::{Rng as _, SeedableRng as _, rngs::SmallRng};
     use std::io::Cursor;
 
     fn memory_image(src: &[u8]) -> image::Image<Cursor<&[u8]>, Cursor<Vec<u8>>> {

--- a/src/bin/avml-upload.rs
+++ b/src/bin/avml-upload.rs
@@ -1,18 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#![deny(clippy::unwrap_used)]
-#![deny(clippy::expect_used)]
-#![deny(clippy::panic)]
-#![deny(clippy::manual_assert)]
-#![deny(clippy::indexing_slicing)]
-
 use avml::{BlobUploader, Error, Result, put};
 use clap::{Parser, Subcommand};
-use std::{
-    num::{NonZeroU64, NonZeroUsize},
-    path::PathBuf,
-};
+use core::num::{NonZeroU64, NonZeroUsize};
+use std::path::PathBuf;
 use tokio::runtime::Runtime;
 use url::Url;
 

--- a/src/bin/avml.rs
+++ b/src/bin/avml.rs
@@ -1,23 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#![deny(clippy::unwrap_used)]
-#![deny(clippy::expect_used)]
-#![deny(clippy::panic)]
-#![deny(clippy::manual_assert)]
-#![deny(clippy::indexing_slicing)]
-
-#[cfg(any(feature = "blobstore", feature = "put"))]
-use avml::Error;
 use avml::{Result, Snapshot, Source, iomem};
 use clap::Parser;
 #[cfg(feature = "blobstore")]
-use std::num::NonZeroUsize;
-use std::{num::NonZeroU64, ops::Range, path::PathBuf};
+use core::num::NonZeroUsize;
+use core::{num::NonZeroU64, ops::Range};
+use std::path::PathBuf;
 #[cfg(any(feature = "blobstore", feature = "put"))]
-use tokio::{fs::remove_file, runtime::Runtime};
-#[cfg(any(feature = "blobstore", feature = "put"))]
-use url::Url;
+use {
+    avml::Error,
+    tokio::{fs::remove_file, runtime::Runtime},
+    url::Url,
+};
 
 #[derive(Parser)]
 /// A portable volatile memory acquisition tool for Linux
@@ -90,7 +85,7 @@ async fn upload(config: &Config) -> Result<()> {
 
     #[cfg(feature = "put")]
     {
-        if let Some(url) = &config.url {
+        if let Some(ref url) = config.url {
             avml::put(&config.filename, url).await?;
             delete = true;
         }
@@ -98,7 +93,7 @@ async fn upload(config: &Config) -> Result<()> {
 
     #[cfg(feature = "blobstore")]
     {
-        if let Some(sas_url) = &config.sas_url {
+        if let Some(ref sas_url) = config.sas_url {
             let uploader = avml::BlobUploader::new(sas_url)?
                 .block_size(config.sas_block_size)
                 .concurrency(config.sas_block_concurrency);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#![deny(clippy::undocumented_unsafe_blocks)]
-#![deny(clippy::unwrap_used)]
-#![deny(clippy::expect_used)]
-#![deny(clippy::panic)]
-#![deny(clippy::manual_assert)]
-#![deny(clippy::indexing_slicing)]
-#![deny(clippy::redundant_pub_crate)]
-#![deny(clippy::if_then_some_else_none)]
-#![deny(clippy::shadow_unrelated)]
-#![deny(clippy::std_instead_of_core)]
-#![warn(clippy::assertions_on_result_states)]
-#![warn(clippy::if_then_some_else_none)]
-#![warn(clippy::needless_continue)]
-#![warn(clippy::redundant_pub_crate)]
-#![warn(clippy::shadow_unrelated)]
-#![warn(clippy::std_instead_of_core)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::unused_trait_names)]
-#![warn(clippy::verbose_file_reads)]
-#![warn(clippy::arithmetic_side_effects)]
-#![warn(clippy::as_conversions)]
-#![warn(clippy::pattern_type_mismatch)]
-// #![warn(clippy::missing_errors_doc)]
-
 #[cfg(target_family = "unix")]
 mod disk_usage;
 pub mod errors;


### PR DESCRIPTION
`src/lib.rs` and each `src/bin/*.rs` carried their own `#![deny]` /
`#![warn]` blocks, with the binaries running a strict subset of the
library's lints. Move the full set into `[lints.clippy]` in
`Cargo.toml` (Rust 1.74+, well within `rust-version = 1.88.0`), which
applies uniformly to every target in the package.

Deduplicated the lib's mixed deny/warn entries (e.g. `shadow_unrelated`
appeared in both lists) — deny wins when a lint was in both. No lint
loosens; binaries now match the library's strictness.

Applying the full set to the binaries surfaced a handful of new
issues. Fixed inline:

- `std_instead_of_core`: `std::num::*` and `std::ops::Range` in both
  binary entrypoints switched to `core::`.
- `arithmetic_side_effects` in `avml-convert.rs`: `header.range.start
  - current_dst` and `unmapped -= ONE_MB` use `saturating_sub`. The
  while-loop predicate already guarantees the latter doesn't
  underflow; the former silently produces zero padding on malformed
  input rather than panicking.
- `unused_trait_names` in `avml-convert.rs` tests: `use rand::{Rng,
  SeedableRng, ...}` rebound with `as _`.
- `pattern_type_mismatch` in `avml.rs`: `if let Some(url) =
  &config.url` switched to `if let Some(ref url) = config.url`.

Verified with:

- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo clippy --no-default-features --all-targets -- -D warnings`
- `cargo test --all-features`
- `cargo fmt --check`