### PR TITLE
Add #[from] to snapshot::Error::Elf

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -25,7 +25,7 @@ use std::{
 #[derive(thiserror::Error)]
 pub enum Error {
     #[error("unable to parse elf structures: {0}")]
-    Elf(elf::ParseError),
+    Elf(#[from] elf::ParseError),
 
     #[error("locked down /proc/kcore")]
     LockedDownKcore,
@@ -339,8 +339,7 @@ impl<'a, 'b> Snapshot<'a, 'b> {
             Image::<File, File>::new(self.version, Path::new("/proc/kcore"), self.destination)?;
         self.check_disk_usage(&image)?;
 
-        let file =
-            elf::ElfStream::<NativeEndian, _>::open_stream(&mut image.src).map_err(Error::Elf)?;
+        let file = elf::ElfStream::<NativeEndian, _>::open_stream(&mut image.src)?;
         let mut segments: Vec<&ProgramHeader> = file
             .segments()
             .iter()


### PR DESCRIPTION
The other upstream-error variants in `snapshot::Error` (image, io,
etc.) all use `#[from]` so `?` propagates them, but
`Elf(elf::ParseError)` was hand-converted via `.map_err(Error::Elf)`
at the one call site. Mark it `#[from]` and drop the manual
conversion for consistency.