### PR TITLE
Preserve the source error from Image::write_blocks

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -32,8 +32,12 @@ pub enum Error {
     #[error("unsupported format")]
     UnsupportedFormat,
 
-    #[error("write block failed: {0:?}")]
-    WriteBlock(Range<u64>),
+    #[error("write block failed: {range:?}")]
+    WriteBlock {
+        range: Range<u64>,
+        #[source]
+        source: Box<Error>,
+    },
 
     #[error(transparent)]
     IntConversion(#[from] core::num::TryFromIntError),
@@ -243,8 +247,10 @@ impl<R: Read + Seek, W: Write> Image<R, W> {
     /// Returns an error if writing any block fails
     pub fn write_blocks(&mut self, blocks: &[Block]) -> Result<()> {
         for block in blocks {
-            self.write_block(block)
-                .map_err(|_| Error::WriteBlock(block.range.clone()))?;
+            self.write_block(block).map_err(|e| Error::WriteBlock {
+                range: block.range.clone(),
+                source: Box::new(e),
+            })?;
         }
         Ok(())
     }


### PR DESCRIPTION
`write_blocks` wrapped a per-block failure into
`Error::WriteBlock(range)` via `.map_err(|_| ...)`, dropping the
underlying error (and its `#[source]` chain) on the floor. The user
got "write block failed: Range { start: ..., end: ... }" with no clue
whether the failure was an I/O error on the source, an I/O error on
the destination, an integer-conversion overflow, a snappy finalize,
etc.

Promote `WriteBlock` to a struct variant carrying a boxed source
error and pass the original error through `map_err`. The chained
`Display` walker in `errors::format_error` then renders the full
chain.

Verified with:

- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo clippy --no-default-features --all-targets -- -D warnings`
- `cargo test --all-features`
- `cargo fmt --check`