### PR TITLE
Cache Cargo state in the lint job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
     - uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
       with:
         crate: typos-cli
+        locked: true
     - uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
       with:
         crate: cargo-semver-checks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6.0.2
+    - uses: Swatinem/rust-cache@65012b490220f477f20ab979e35ae732e6de4e68 # v2
+    - uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+      with:
+        crate: typos-cli
+    - uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+      with:
+        crate: cargo-semver-checks
+        locked: true
     - name: lint
       run: eng/lint.sh
   x64:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6.0.2
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@65012b490220f477f20ab979e35ae732e6de4e68 # v2
     - name: build
       run: eng/ci.sh
     - name: Run tests
@@ -45,7 +53,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
     - uses: actions/checkout@v6.0.2
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@65012b490220f477f20ab979e35ae732e6de4e68 # v2
     - name: build
       run: eng/ci.sh
     - name: Run tests
@@ -69,7 +77,7 @@ jobs:
         git config --global core.autocrlf false
         git config --global core.eol lf
     - uses: actions/checkout@v6.0.2
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@65012b490220f477f20ab979e35ae732e6de4e68 # v2
     - name: build avml-convert
       run: cargo build --release --bin avml-convert --locked
     - name: build avml-upload


### PR DESCRIPTION
The lint job ran `cargo clippy --locked --all-targets --all-features`
plus `cargo semver-checks check-release` on every push and PR with no
cache, recompiling the full dependency tree each time. The other CI
jobs (x64, arm64, windows) already use `Swatinem/rust-cache@v2`; add
it here too.

Note: this caches `~/.cargo/registry`, `~/.cargo/git`, and the
project's `target/` directory. It does not cache `~/.cargo/bin`, so
the `cargo install typos-cli` and `cargo install cargo-semver-checks`
invocations in `eng/lint.sh` will still recompile on a cold cache.
Keeping them in the script preserves the run-locally workflow; a
follow-up could add an `actions/cache` step on `~/.cargo/bin` if the
tool install time becomes noticeable.