### PR TITLE
Differentiate MAX_CONCURRENCY and DEFAULT_CONCURRENCY doc comments

### DIFF
--- a/src/upload/blobstore.rs
+++ b/src/upload/blobstore.rs
@@ -63,23 +63,26 @@ const BLOB_MAX_FILE_SIZE: NonZeroU64 = BLOB_MAX_BLOCKS.saturating_mul(BLOB_MAX_B
 const BLOB_MIN_BLOCK_SIZE: NonZeroU64 = ONE_MB_NZ
     .saturating_mul(NonZeroU64::new(5).expect("blob min block size multiplier must be non-zero"));
 
-/// Azure's default max request rate for a storage account is 20,000 per second.
-/// By keeping to 10 or fewer concurrent upload threads, AVML can be used to
-/// simultaneously upload images from 1000 different hosts concurrently (a full
-/// VM scaleset) to a single default storage account.
+/// Hard cap on concurrent upload tasks, applied after any caller-supplied or
+/// memory-derived value. Azure's default max request rate for a storage
+/// account is 20,000/sec; capping at 10 concurrent uploaders per host lets
+/// 1000 hosts (a full VM scaleset) target a single default storage account
+/// simultaneously without tripping throttling.
 ///
 /// <https://docs.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account#scale-targets-for-standard-storage-accounts>
 const MAX_CONCURRENCY: NonZeroUsize =
     NonZeroUsize::new(10).expect("max concurrency must be non-zero");
 
-/// Azure's default max request rate for a storage account is 20,000 per second.
-/// By keeping to 10 or fewer concurrent upload threads, AVML can be used to
-/// simultaneously upload images from 1000 different hosts concurrently (a full
-/// VM scaleset) to a single default storage account.
-///
-/// <https://docs.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account#scale-targets-for-standard-storage-accounts>
+/// Default concurrent upload tasks when the caller does not specify one.
+/// Currently matches [`MAX_CONCURRENCY`] so the out-of-the-box behavior is
+/// also the per-host cap; see that constant for the scaleset rationale.
 pub const DEFAULT_CONCURRENCY: NonZeroUsize =
     NonZeroUsize::new(10).expect("default concurrency must be non-zero");
+
+const _: () = assert!(
+    DEFAULT_CONCURRENCY.get() <= MAX_CONCURRENCY.get(),
+    "DEFAULT_CONCURRENCY must not exceed MAX_CONCURRENCY",
+);
 
 /// Keep at most 500MB of block data in flight across all uploaders.
 const MEMORY_THRESHOLD: NonZeroU64 = ONE_MB_NZ


### PR DESCRIPTION
The two constants in `src/upload/blobstore.rs` carried identical
multi-line rationale, so the comments didn't distinguish the per-host
cap from the default that applies when the caller passes `None`.
Anyone bumping the default to handle a user request would have had to
notice the cap by reading code, not docs — exactly the drift the
duplication invited.

Rewrite each comment to describe what its constant actually controls:

- `MAX_CONCURRENCY` is the hard cap applied after caller-supplied and
  memory-derived values. Keeps the scaleset rationale where it
  matters.
- `DEFAULT_CONCURRENCY` is the value used when the caller passes
  `None`. References `MAX_CONCURRENCY` for the underlying reasoning.

silently exceed the cap if either value changes later.

Verified with:

- `cargo fmt --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features`