### PR TITLE
Use tempfile::TempDir in test_progress_stream_reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "rand",
  "reqwest",
  "snap",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ url = {version="2.5", optional=true, default-features=false}
 [dev-dependencies]
 insta = {version="1.47", features=["json"]}
 rand = {version="0.10", default-features=false, features=["std_rng"]}
+tempfile = "3"
 
 [lints.clippy]
 arithmetic_side_effects = "warn"

--- a/src/upload/blobstore.rs
+++ b/src/upload/blobstore.rs
@@ -301,7 +301,6 @@ mod tests {
     use super::*;
     use crate::ONE_MB;
     use futures::AsyncReadExt as _;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn non_zero(value: u64) -> Result<NonZeroU64> {
         NonZeroU64::new(value).ok_or(Error::TooLarge)
@@ -402,39 +401,27 @@ mod tests {
 
     #[tokio::test]
     async fn test_progress_stream_reset() -> Result<()> {
-        let path = std::env::temp_dir().join(format!(
-            "avml-blob-upload-{}-{}.bin",
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        ));
+        let dir = tempfile::TempDir::new()?;
+        let path = dir.path().join("blob-upload.bin");
         let expected = b"seekable stream content";
         tokio::fs::write(&path, expected).await?;
 
-        let result = async {
-            let file = File::open(&path).await?;
-            let file_size = file.metadata().await?.len();
-            let mut stream = ProgressStream::new(file, file_size).await?;
+        let file = File::open(&path).await?;
+        let file_size = file.metadata().await?.len();
+        let mut stream = ProgressStream::new(file, file_size).await?;
 
-            assert_eq!(stream.len(), Some(u64::try_from(expected.len())?));
+        assert_eq!(stream.len(), Some(u64::try_from(expected.len())?));
 
-            let mut prefix = [0_u8; 8];
-            stream.read_exact(&mut prefix).await?;
-            assert_eq!(&prefix, b"seekable");
+        let mut prefix = [0_u8; 8];
+        stream.read_exact(&mut prefix).await?;
+        assert_eq!(&prefix, b"seekable");
 
-            stream.reset().await?;
+        stream.reset().await?;
 
-            let mut reread = Vec::new();
-            stream.read_to_end(&mut reread).await?;
-            assert_eq!(reread, expected);
+        let mut reread = Vec::new();
+        stream.read_to_end(&mut reread).await?;
+        assert_eq!(reread, expected);
 
-            Result::<()>::Ok(())
-        }
-        .await;
-
-        let _ = tokio::fs::remove_file(&path).await;
-        result
+        Ok(())
     }
 }


### PR DESCRIPTION
`test_progress_stream_reset` in `src/upload/blobstore.rs` wrote to
`std::env::temp_dir()` with a hand-rolled pid+nanos filename, ran
the test body inside an `async {}` block to capture its Result, then
manually `remove_file`'d the path. A panic or early return inside
the async block skipped the cleanup, leaking files into `$TMPDIR`
across CI runs.

Use `tempfile::TempDir` instead. Cleanup runs on `Drop` (panic-safe),
collision-avoidance is structural, and the test body collapses back
to straight `?`-propagation without the inner async block.

- Drops the now-unused `std::time::{SystemTime, UNIX_EPOCH}` import.
- Adds `tempfile = "3"` to `[dev-dependencies]` (`Cargo.lock` churn
  picks up the standard tempfile transitive deps).

Verified with:

- `cargo fmt --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features` (`test_progress_stream_reset` passes)