### PR TITLE
Use named fields on UnableToCreateSnapshotFromSource; escape Raw paths in Display

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -138,6 +138,15 @@ impl FmtDisplay for Source {
             Self::DevCrash => write!(f, "/dev/crash"),
             Self::DevMem => write!(f, "/dev/mem"),
             Self::ProcKcore => write!(f, "/proc/kcore"),
+            // Deliberately use Debug formatting rather than `path.display()`:
+            // this value is embedded in error messages that may be logged or
+            // shown in CI annotations. Debug quotes and escapes control
+            // characters, ANSI sequences, and embedded newlines; Display via
+            // `path.display()` would let them through verbatim.
+            #[expect(
+                clippy::unnecessary_debug_formatting,
+                reason = "escaping is the point — see comment above"
+            )]
             Self::Raw(ref path) => write!(f, "{path:?}"),
         }
     }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -38,8 +38,12 @@ pub enum Error {
     #[error("unable to create memory snapshot")]
     UnableToCreateMemorySnapshot(#[from] crate::image::Error),
 
-    #[error("unable to create memory snapshot from source: {1}")]
-    UnableToCreateSnapshotFromSource(#[source] Box<Error>, Source),
+    #[error("unable to create memory snapshot from source: {src}")]
+    UnableToCreateSnapshotFromSource {
+        src: Source,
+        #[source]
+        source: Box<Error>,
+    },
 
     #[error("no memory source available")]
     NoSourceAvailable,
@@ -134,7 +138,7 @@ impl FmtDisplay for Source {
             Self::DevCrash => write!(f, "/dev/crash"),
             Self::DevMem => write!(f, "/dev/mem"),
             Self::ProcKcore => write!(f, "/proc/kcore"),
-            Self::Raw(ref path) => write!(f, "{}", path.display()),
+            Self::Raw(ref path) => write!(f, "{path:?}"),
         }
     }
 }
@@ -168,7 +172,7 @@ macro_rules! try_method {
         match $func {
             Ok(x) => return Ok(x),
             Err(err) => {
-                if let Error::UnableToCreateSnapshotFromSource(ref x, _) = err {
+                if let Error::UnableToCreateSnapshotFromSource { source: ref x, .. } = err {
                     if let Error::DiskUsageEstimateExceeded { .. } = **x {
                         return Err(err);
                     }
@@ -245,7 +249,10 @@ impl<'a, 'b> Snapshot<'a, 'b> {
             Source::DevMem => self.phys(Path::new("/dev/mem")),
             Source::Raw(ref s) => self.phys(s),
         }
-        .map_err(|e| Error::UnableToCreateSnapshotFromSource(Box::new(e), src.clone()))
+        .map_err(|e| Error::UnableToCreateSnapshotFromSource {
+            src: src.clone(),
+            source: Box::new(e),
+        })
     }
 
     /// Create a memory snapshot


### PR DESCRIPTION
Two surgical changes in `src/snapshot.rs`.

### 1. Named fields on `UnableToCreateSnapshotFromSource`

```rust
// before
UnableToCreateSnapshotFromSource(#[source] Box<Error>, Source)

// after
UnableToCreateSnapshotFromSource {
    src: Source,
    #[source]
    source: Box<Error>,
}
```

It was the only positional-tuple variant in this error enum —
`Error::Io`, `Error::WriteBlock`, `Error::DiskUsageEstimateExceeded`,
and `Error::Other` all use named fields. The construction site in
`create_source` is now self-documenting:

```rust
.map_err(|e| Error::UnableToCreateSnapshotFromSource {
    src: src.clone(),
    source: Box::new(e),
})
```

### 2. Escape `Source::Raw` paths in `Display`

```rust
// before
Self::Raw(ref path) => write!(f, "{}", path.display()),

// after
Self::Raw(ref path) => write!(f, "{path:?}"),
```

`path.display()` is lossy-but-prints-anything — control characters,
ANSI escapes, embedded newlines all flow verbatim into error messages
that may be logged or rendered in CI annotations. `PathBuf`'s `Debug`
quotes and escapes, which is the right default inside a structured
error.

### Scope and compatibility

- One file, +12/−5.
- Internal callers updated: the one pattern match (inside the
  `try_method!` macro; #801 deletes the macro entirely but this PR
  stands alone either way) and the one construction site.
- `Error` is `pub`, so the variant rename is technically visible to
  any external `match` arm. The only documented downstream is this
  crate's own custom `Debug` impl, which goes through `Display`.

### Not included

The larger restructure I described — splitting `Source` into a
`KernelSource` enum (the three well-known kernel devices, fully
`ValueEnum`-exposed) plus a separate `Snapshot::raw_source(path)`
builder method — is a public-API change worth raising as an issue
first. `Source::Raw` is currently `#[value(skip)]`, so it's library-
only and doesn't participate in the auto-detect fallback; that split
would tighten the type but break any external library consumer.

Verified with:

- `cargo fmt --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features`
