### PR TITLE
Replace snapshot::Error::Other with typed variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "avml"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "azure_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avml"
-version = "0.18.0"
+version = "0.19.0"
 license = "MIT"
 description = "A portable volatile memory acquisition tool"
 authors = ["avml@microsoft.com"]

--- a/src/disk_usage.rs
+++ b/src/disk_usage.rs
@@ -138,7 +138,9 @@ fn disk_usage(path: &Path) -> Result<DiskUsage> {
         return Err(Error::Disk(std::io::Error::last_os_error()));
     }
 
-    let f_bsize: u64 = statfs.f_bsize.try_into().map_err(Error::BlockSize)?;
+    let raw_bsize = i128::from(statfs.f_bsize);
+    let f_bsize: u64 =
+        u64::try_from(raw_bsize).map_err(|_| Error::BlockSize { value: raw_bsize })?;
 
     let total = statfs.f_blocks.saturating_mul(f_bsize);
     let free = statfs.f_bavail.saturating_mul(f_bsize);

--- a/src/disk_usage.rs
+++ b/src/disk_usage.rs
@@ -90,10 +90,7 @@ fn check_max_usage_percentage(
 )]
 fn u64_to_f64(value: u64) -> Result<f64> {
     if value > EXCESSIVE_VALUE {
-        return Err(Error::Other {
-            context: "unable to convert u64 to f64",
-            detail: format!("value is too large to convert to f64: {value}"),
-        });
+        return Err(Error::F64Conversion { value });
     }
     Ok(value as f64)
 }
@@ -112,10 +109,7 @@ fn u64_to_f64(value: u64) -> Result<f64> {
 )]
 fn f64_to_u64(value: f64) -> Result<u64> {
     if !value.is_sign_positive() {
-        return Err(Error::Other {
-            context: "unable to convert f64 to u64",
-            detail: format!("value is not a positive f64: {value}"),
-        });
+        return Err(Error::U64Conversion { value });
     }
     Ok(value.trunc() as u64)
 }
@@ -133,10 +127,7 @@ fn estimate(ranges: &[Range<u64>]) -> u64 {
 }
 
 fn disk_usage(path: &Path) -> Result<DiskUsage> {
-    let path_as_cstr = CString::new(path.as_os_str().as_bytes()).map_err(|e| Error::Other {
-        context: "unable to convert path to CString",
-        detail: e.to_string(),
-    })?;
+    let path_as_cstr = CString::new(path.as_os_str().as_bytes())?;
 
     // SAFETY: this is the only way to initialize the statfs64 struct
     let mut statfs: libc::statfs64 = unsafe { zeroed() };
@@ -147,10 +138,7 @@ fn disk_usage(path: &Path) -> Result<DiskUsage> {
         return Err(Error::Disk(std::io::Error::last_os_error()));
     }
 
-    let f_bsize: u64 = statfs.f_bsize.try_into().map_err(|e| Error::Other {
-        context: "unable to identify block size",
-        detail: format!("{e}"),
-    })?;
+    let f_bsize: u64 = statfs.f_bsize.try_into().map_err(Error::BlockSize)?;
 
     let total = statfs.f_blocks.saturating_mul(f_bsize);
     let free = statfs.f_bavail.saturating_mul(f_bsize);
@@ -169,18 +157,18 @@ mod tests {
     )]
 
     use super::*;
+    use std::path::PathBuf;
 
     const EXCESSIVE_VALUE_F64: f64 = 4_000_000_000_000_000_000.0;
+    const TEN: NonZeroU64 = NonZeroU64::new(10).expect("10 is non-zero");
 
     #[test]
     fn test_disk_usage() -> Result<()> {
-        let current_exe = std::env::current_exe().map_err(|e| Error::Other {
-            context: "unable to get current exe",
-            detail: e.to_string(),
-        })?;
-        // check that we can get disk usage for at least one file system, here
-        // we check file system that the current exe resides on
-        let result = disk_usage(&current_exe)?;
+        // Use the crate's source directory; per the testing convention,
+        // CARGO_MANIFEST_DIR is a stable fixture path that doesn't depend
+        // on the test binary's location.
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let result = disk_usage(&path)?;
 
         // We can't really test this, but we can at least make sure it's not zero
         assert!(result.total > 0);
@@ -225,13 +213,9 @@ mod tests {
 
     #[test]
     fn test_check_max_usable() -> Result<()> {
-        let ten = NonZeroU64::new(10).ok_or(Error::Other {
-            context: "unable to create NonZeroU64",
-            detail: String::new(),
-        })?;
-        check_max_usage(1, ten)?;
-        check_max_usage(10, ten)?;
-        assert!(check_max_usage(11 * 1024 * 1024, ten).is_err());
+        check_max_usage(1, TEN)?;
+        check_max_usage(10, TEN)?;
+        assert!(check_max_usage(11 * 1024 * 1024, TEN).is_err());
         Ok(())
     }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -70,8 +70,8 @@ pub enum Error {
     #[error("snapshot destination path contains a NUL byte")]
     PathContainsNul(#[from] std::ffi::NulError),
 
-    #[error("filesystem block size does not fit in a u64")]
-    BlockSize(#[source] core::num::TryFromIntError),
+    #[error("filesystem block size {value} does not fit in a u64")]
+    BlockSize { value: i128 },
 
     #[error("operation not supported on this platform: {os}")]
     UnsupportedPlatform { os: &'static str },

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -61,11 +61,20 @@ pub enum Error {
     #[error("unable to parse /proc/kcore: {0}")]
     KcoreParse(&'static str),
 
-    #[error("{context}: {detail}")]
-    Other {
-        context: &'static str,
-        detail: String,
-    },
+    #[error("u64 value {value} is too large to convert to f64")]
+    F64Conversion { value: u64 },
+
+    #[error("f64 value {value} cannot be converted to u64")]
+    U64Conversion { value: f64 },
+
+    #[error("snapshot destination path contains a NUL byte")]
+    PathContainsNul(#[from] std::ffi::NulError),
+
+    #[error("filesystem block size does not fit in a u64")]
+    BlockSize(#[source] core::num::TryFromIntError),
+
+    #[error("operation not supported on this platform: {os}")]
+    UnsupportedPlatform { os: &'static str },
 
     #[error("disk error")]
     Disk(#[source] std::io::Error),
@@ -374,10 +383,7 @@ impl<'a, 'b> Snapshot<'a, 'b> {
     #[cfg(not(target_family = "unix"))]
     fn check_disk_usage<R: Read + Seek, W: Write>(&self, _: &Image<R, W>) -> Result<()> {
         if self.max_disk_usage.is_some() || self.max_disk_usage_percentage.is_some() {
-            return Err(Error::Other {
-                context: "unable to check disk usage on this platform",
-                detail: format!("os:{OS}"),
-            });
+            return Err(Error::UnsupportedPlatform { os: OS });
         }
         Ok(())
     }


### PR DESCRIPTION
`Error::Other { context: &'static str, detail: String }` was the last stringly-typed error path in the crate. Split into specific variants for each call site:

- `F64Conversion { value: u64 }` and `U64Conversion { value: f64 }` for the bounded `f64` ↔ `u64` conversions in `disk_usage`.
- `PathContainsNul(#[from] std::ffi::NulError)` for `CString::new` failures on the snapshot destination path.
- `BlockSize(#[source] TryFromIntError)` for `statfs64` `f_bsize` widening.
- `UnsupportedPlatform { os: &'static str }` for the non-unix branch of `check_disk_usage`.

### Test cleanups while in here

- `test_disk_usage` uses `CARGO_MANIFEST_DIR` instead of `current_exe()`, matching the testing convention for fixture paths.
- `test_check_max_usable` hoists the `NonZeroU64` literal into a const, removing the `Error::Other` fallback path.

### Verified locally

- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings -D clippy::pedantic -A clippy::missing_errors_doc`
- `cargo test --all-features` (28 lib + 2 convert + 1 doctest pass)