### PR TITLE
Simplify Snapshot lifetime and source builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "avml"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "azure_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avml"
-version = "0.18.0"
+version = "0.19.0"
 license = "MIT"
 description = "A portable volatile memory acquisition tool"
 authors = ["avml@microsoft.com"]

--- a/src/bin/avml.rs
+++ b/src/bin/avml.rs
@@ -115,7 +115,7 @@ fn acquire(config: &Config) -> Result<()> {
 
     let ranges = iomem::parse()?;
     let snapshot = Snapshot::new(&config.filename, ranges)
-        .source(config.source.as_ref())
+        .source(config.source.clone())
         .max_disk_usage_percentage(config.max_disk_usage_percentage)
         .max_disk_usage(config.max_disk_usage)
         .version(version);

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -184,8 +184,8 @@ fn is_kcore_ok() -> bool {
         && can_open(Path::new("/proc/kcore"))
 }
 
-pub struct Snapshot<'a, 'b> {
-    source: Option<&'b Source>,
+pub struct Snapshot<'a> {
+    source: Option<Source>,
     destination: &'a Path,
     memory_ranges: Vec<Range<u64>>,
     version: u32,
@@ -193,7 +193,7 @@ pub struct Snapshot<'a, 'b> {
     max_disk_usage_percentage: Option<f64>,
 }
 
-impl<'a, 'b> Snapshot<'a, 'b> {
+impl<'a> Snapshot<'a> {
     /// Create a new memory snapshot.
     ///
     /// The default version implements the `LiME` format.
@@ -233,7 +233,7 @@ impl<'a, 'b> Snapshot<'a, 'b> {
 
     /// Specify the source for creating the snapshot
     #[must_use]
-    pub fn source(self, source: Option<&'b Source>) -> Self {
+    pub fn source(self, source: Option<Source>) -> Self {
         Self { source, ..self }
     }
 
@@ -265,7 +265,7 @@ impl<'a, 'b> Snapshot<'a, 'b> {
     /// - The estimated disk usage exceeds the specified limits
     /// - Failed to create or write to the destination file
     pub fn create(&self) -> Result<()> {
-        if let Some(src) = self.source {
+        if let Some(ref src) = self.source {
             self.create_source(src)?;
         } else if self.destination == Path::new("/dev/stdout") {
             // If we're writing to stdout, we can't start over if reading from a


### PR DESCRIPTION
Two small `Snapshot` API tidies:

- Collapse `Snapshot<'a, 'b>` to `Snapshot<'a>`. The two lifetimes never need to differ at any caller.
- `Snapshot::source` takes `Option<Source>` by value instead of `Option<&Source>`. `Source` is `Clone` (`PathBuf` at most), and `create_source` already clones it. Removes the borrow lifetime and the `.as_ref()` ceremony at the call site.

### Verified locally

- `cargo fmt`
- `cargo clippy --locked --all-targets --all-features -- -D warnings -D clippy::pedantic -A clippy::missing_errors_doc`
- `cargo test --all-features`