### PR TITLE
Rename MB to MiB where math is power-of-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "avml"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "azure_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avml"
-version = "0.19.0"
+version = "0.19.1"
 license = "MIT"
 description = "A portable volatile memory acquisition tool"
 authors = ["avml@microsoft.com"]

--- a/src/bin/avml/acquire.rs
+++ b/src/bin/avml/acquire.rs
@@ -20,7 +20,7 @@ pub struct Args {
     #[arg(long, value_enum)]
     source: Option<Source>,
 
-    /// Specify the maximum estimated disk usage (in MB)
+    /// Specify the maximum estimated disk usage (in MiB)
     #[arg(long)]
     max_disk_usage: Option<NonZeroU64>,
 

--- a/src/disk_usage.rs
+++ b/src/disk_usage.rs
@@ -44,7 +44,7 @@ pub fn check(
 }
 
 fn check_max_usage(estimated: u64, max_disk_usage: NonZeroU64) -> Result<()> {
-    // convert to MB
+    // convert to MiB
     let allowed = max_disk_usage
         .get()
         .saturating_mul(1024)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ pub use crate::{
     snapshot::{Snapshot, Source},
 };
 
-pub const ONE_MB: usize = 1024 * 1024;
+pub const ONE_MIB: usize = 1024 * 1024;
+
+#[deprecated(since = "0.19.1", note = "use ONE_MIB instead")]
+pub const ONE_MB: usize = ONE_MIB;
 
 pub type Result<T> = core::result::Result<T, crate::errors::Error>;

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -135,7 +135,7 @@ pub enum Source {
     /// disabled using the kernel configuration options `CONFIG_STRICT_DEVMEM`
     /// or `CONFIG_IO_STRICT_DEVMEM`.
     ///
-    /// With `CONFIG_STRICT_DEVMEM`, only the first 1MB of memory can be
+    /// With `CONFIG_STRICT_DEVMEM`, only the first 1MiB of memory can be
     /// accessed.
     #[value(name = "/dev/mem")]
     DevMem,
@@ -229,7 +229,7 @@ impl<'a> Snapshot<'a> {
         }
     }
 
-    /// Specify the maximum disk space in MB to use
+    /// Specify the maximum disk space in MiB to use
     ///
     /// This is an estimation, calculated at start time
     #[must_use]

--- a/src/upload/blobstore.rs
+++ b/src/upload/blobstore.rs
@@ -36,7 +36,7 @@ pub enum Error {
 
 type Result<T> = core::result::Result<T, Error>;
 
-const ONE_MB_NZ: NonZeroU64 = NonZeroU64::new(1024 * 1024).expect("ONE_MB must be non-zero");
+const ONE_MIB_NZ: NonZeroU64 = NonZeroU64::new(1024 * 1024).expect("ONE_MIB must be non-zero");
 
 /// Maximum number of blocks
 ///
@@ -47,7 +47,7 @@ const BLOB_MAX_BLOCKS: NonZeroU64 =
 /// Maximum size of any single block
 ///
 /// <https://docs.microsoft.com/en-us/azure/storage/blobs/scalability-targets#scale-targets-for-blob-storage>
-const BLOB_MAX_BLOCK_SIZE: NonZeroU64 = ONE_MB_NZ.saturating_mul(
+const BLOB_MAX_BLOCK_SIZE: NonZeroU64 = ONE_MIB_NZ.saturating_mul(
     NonZeroU64::new(4000).expect("blob max block size multiplier must be non-zero"),
 );
 
@@ -60,7 +60,7 @@ const BLOB_MAX_FILE_SIZE: NonZeroU64 = BLOB_MAX_BLOCKS.saturating_mul(BLOB_MAX_B
 /// blobs" feature on all storage accounts
 ///
 /// <https://azure.microsoft.com/en-us/blog/high-throughput-with-azure-blob-storage/>
-const BLOB_MIN_BLOCK_SIZE: NonZeroU64 = ONE_MB_NZ
+const BLOB_MIN_BLOCK_SIZE: NonZeroU64 = ONE_MIB_NZ
     .saturating_mul(NonZeroU64::new(5).expect("blob min block size multiplier must be non-zero"));
 
 /// Hard cap on concurrent upload tasks, applied after any caller-supplied or
@@ -84,8 +84,8 @@ const _: () = assert!(
     "DEFAULT_CONCURRENCY must not exceed MAX_CONCURRENCY",
 );
 
-/// Keep at most 500MB of block data in flight across all uploaders.
-const MEMORY_THRESHOLD: NonZeroU64 = ONE_MB_NZ
+/// Keep at most 500MiB of block data in flight across all uploaders.
+const MEMORY_THRESHOLD: NonZeroU64 = ONE_MIB_NZ
     .saturating_mul(NonZeroU64::new(500).expect("memory threshold multiplier must be non-zero"));
 
 fn calc_block_size(file_size: NonZeroU64, block_size: Option<NonZeroU64>) -> Result<NonZeroU64> {
@@ -149,7 +149,7 @@ fn upload_parameters(
     block_size: Option<NonZeroU64>,
     upload_concurrency: Option<NonZeroUsize>,
 ) -> Result<UploadPlan> {
-    let block_size = block_size.map(|x| x.saturating_mul(ONE_MB_NZ));
+    let block_size = block_size.map(|x| x.saturating_mul(ONE_MIB_NZ));
     calc_concurrency(file_size, block_size, upload_concurrency)
 }
 
@@ -259,7 +259,7 @@ impl BlobUploader {
         }
     }
 
-    /// Specify a positive block size in multiples of 1MB.
+    /// Specify a positive block size in multiples of 1MiB.
     #[must_use]
     pub fn block_size(self, block_size: Option<NonZeroU64>) -> Self {
         Self { block_size, ..self }
@@ -313,7 +313,7 @@ impl BlobUploader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ONE_MB;
+    use crate::ONE_MIB;
     use futures::AsyncReadExt as _;
 
     fn non_zero(value: u64) -> Result<NonZeroU64> {
@@ -327,7 +327,7 @@ mod tests {
     fn bytes_from_mib(mebibytes: u64) -> Result<NonZeroU64> {
         non_zero(
             mebibytes
-                .checked_mul(u64::try_from(ONE_MB)?)
+                .checked_mul(u64::try_from(ONE_MIB)?)
                 .ok_or(Error::TooLarge)?,
         )
     }


### PR DESCRIPTION
## Summary
- Renames the public `ONE_MB` constant to `ONE_MIB`, with `ONE_MB` kept as a deprecated compatibility alias.
- Renames internal blob upload `ONE_MB_NZ` to `ONE_MIB_NZ` and updates in-tree callers/tests.
- Updates CLI help, snapshot docs, disk usage comments, and blob upload docs to say MiB for 1024×1024 units.
- Bumps the crate patch version to 0.19.1 for the deprecation metadata.
- No multipliers or runtime values changed.

## Backward compatibility
- `avml::ONE_MB` remains available as a deprecated alias for `avml::ONE_MIB`.
- The existing `--max-disk-usage` flag remains unchanged; only its help text now says MiB.

## Grep-confirmed sites covered
- `src/lib.rs`: public `ONE_MB` renamed to `ONE_MIB`; deprecated alias kept.
- `src/bin/avml/acquire.rs`: `--max-disk-usage` help text changed from MB to MiB.
- `src/disk_usage.rs`: conversion comment changed from MB to MiB.
- `src/snapshot.rs`: devmem and max disk usage docs changed from MB to MiB.
- `src/upload/blobstore.rs`: internal constant, memory threshold doc, block size doc, and tests changed to MiB naming.
- `README.md` and `RELEASE_PROCESS.md`: no `MB`/`megabyte` hits found.

## Validation
- `cargo fmt --all`
- `bash eng/lint.sh` (`cargo semver-checks check-release` passed; no semver update required by the tool)
- `cargo test --all-features`
- `cargo build --all-features`