### PR TITLE
Fix BlobUploader::new doc reference

### DIFF
--- a/src/upload/blobstore.rs
+++ b/src/upload/blobstore.rs
@@ -240,8 +240,9 @@ impl BlobUploader {
     ///
     /// # Errors
     /// Propagates any error returned by
-    /// [`BlobClient::from_url`](azure_storage_blob::BlobClient::from_url),
-    /// for example if the URL shape is not supported by the Azure SDK.
+    /// [`BlobClient::new`](azure_storage_blob::BlobClient::new) when
+    /// constructing the client from `sas`, for example if the URL shape is not
+    /// supported by the Azure SDK.
     pub fn new(sas: &Url) -> Result<Self> {
         let blob_client = BlobClient::new(sas.clone(), None, None)?;
         Ok(Self::with_blob_client(blob_client))


### PR DESCRIPTION
Update the BlobUploader::new error docs to link to BlobClient::new, matching the constructor call used to build the client from the SAS URL instead of the older from_url reference.\n\nValidation:\n- cargo fmt --all\n- bash eng/lint.sh\n- cargo test --all-features\n- cargo build --all-features