### PR TITLE
Require --url or --sas-url when --delete is set

### DIFF
--- a/src/bin/avml/acquire.rs
+++ b/src/bin/avml/acquire.rs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 use avml::{Format, Result, Snapshot, Source, iomem};
+#[cfg(feature = "upload")]
+use clap::ArgGroup;
 use clap::Parser;
 #[cfg(feature = "upload")]
 use core::num::NonZeroUsize;
@@ -11,6 +13,15 @@ use std::path::PathBuf;
 use {avml::Error, tokio::fs::remove_file, url::Url};
 
 #[derive(Parser)]
+#[cfg_attr(
+    feature = "upload",
+    command(group(
+        ArgGroup::new("upload-destination")
+            .args(["url", "sas_url"])
+            .multiple(true)
+            .required(false),
+    ))
+)]
 pub struct Args {
     /// compress via snappy
     #[arg(long)]
@@ -35,7 +46,7 @@ pub struct Args {
 
     /// delete upon successful upload
     #[cfg(feature = "upload")]
-    #[arg(long)]
+    #[arg(long, requires = "upload-destination")]
     delete: bool,
 
     /// upload via Azure Blob Store upon acquisition


### PR DESCRIPTION
## Problem

`avml acquire --delete out.lime` silently leaves the file on disk. The runtime guard in `upload_after_acquire` is `if did_upload && args.delete`, so without any upload flag `did_upload` is `false` and `--delete` is a no-op. Users scripting "acquire and clean up" can't tell that nothing happened.

## Fix

Add a clap `ArgGroup` over `--url` and `--sas-url` and mark `--delete` as `requires = "upload-destination"`. Both arguments and the group are gated on `feature = "upload"`, matching the existing field gating.

Invocation without an upload flag now fails at parse time:

```
$ avml acquire --delete out.lime
error: the following required arguments were not provided:
  <--url <URL>|--sas-url <SAS_URL>>

Usage: avml acquire --delete <--url <URL>|--sas-url <SAS_URL>> <FILENAME>
```

No runtime behavior changes for valid invocations.