### PR TITLE
Document eng/lint.sh in RELEASE_PROCESS

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -11,6 +11,7 @@ If you are the current maintainer of this package:
 
 1. Create a branch for updating the version number of AVML
 1. Bump the version in `Cargo.toml`
+1. Run lint locally using: `./eng/lint.sh`
 1. Build & Locally test with the updated version using: `./eng/ci.sh`
 1. Test on multiple linux versions using: `./eng/test-on-azure.sh`
 1. Commit the updated `Cargo.toml` and `Cargo.lock`


### PR DESCRIPTION
`eng/ci.sh` is already referenced in RELEASE_PROCESS.md; `eng/lint.sh` wasn't. Add it as a step before the local build so the release procedure runs the same checks the lint CI job runs.