### PR TITLE
Add Linux cargo test job to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,15 @@ jobs:
         locked: true
     - name: lint
       run: eng/lint.sh
+  test:
+    permissions:
+        contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.3
+    - uses: Swatinem/rust-cache@c106961feec855ef5a58494c5a2a31c9d80429a9 # v2
+    - name: test
+      run: cargo test --all-features --locked
   x64:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
`eng/lint.sh` runs fmt, clippy, typos, and semver-checks but not tests. The Linux x64/arm64 jobs run a release binary smoke test, not `cargo test`. The Windows job runs `cargo test` but skips `cfg(unix)` tests (e.g. `disk_usage`), so those ran on no CI job at all.

Add a dedicated `test` job on ubuntu-latest that runs `cargo test --all-features --locked`.