### PR TITLE
Describe the actual Azure Blob upload retry policy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ or kernel a priori.  No on-target compilation or fingerprinting is needed.
 
 ## Features
 * Save recorded images to external locations via Azure Blob Store or HTTP PUT
-* Automatic Retry (in case of network connection issues) with exponential backoff for uploading to Azure Blob Store
+* Azure Blob Storage uploads retry transient failures via the Azure SDK's default exponential backoff policy (8 attempts, capped at one minute total elapsed).
 * Optional page level compression using [Snappy](https://google.github.io/snappy/).
 * Uses [LiME](https://github.com/504ensicsLabs/LiME/) output format (when not using compression).
 


### PR DESCRIPTION
## Bug

`README.md:14` claimed:

> Automatic Retry (in case of network connection issues) with exponential backoff for uploading to Azure Blob Store

That implies avml configures retry. It doesn't — `BlobUploader` and `BlockBlobStream` both pass `None` for `ClientOptions`, so the behavior comes entirely from `azure_core`'s defaults.

## Defaults (azure_core 1.0.0)

Per [`RetryOptions`](https://docs.rs/azure_core/1.0.0/azure_core/http/struct.RetryOptions.html) and [`ExponentialRetryOptions`](https://docs.rs/azure_core/1.0.0/azure_core/http/struct.ExponentialRetryOptions.html):

- exponential retry policy
- `max_retries`: 8
- `initial_delay`: 200 ms
- `max_total_elapsed`: 1 minute
- `max_delay`: 30 s

## Fix

Replace the bullet so the README describes what users actually get from the SDK. No code change.

If telemetry later shows the 1-minute cap is too short for forensic snapshot uploads, that's a follow-up that wires `ClientOptions::retry` explicitly.