### PR TITLE
Bump version to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "avml"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "azure_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avml"
-version = "0.19.0"
+version = "0.20.0"
 license = "MIT"
 description = "A portable volatile memory acquisition tool"
 authors = ["avml@microsoft.com"]


### PR DESCRIPTION
## Summary
- Bump the avml package version to 0.20.0
- Update Cargo.lock to match

## Testing
- Not run; version-only change