### PR TITLE
Restrict GitHub Actions token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
## Summary

- set the workflow-level `GITHUB_TOKEN` permission to `contents: read`
- ensure jobs without their own permission block use an explicit least-privilege default

## Impact

The workflow only checks out source, builds, tests, caches dependencies, and uploads workflow artifacts. It does not require repository write permissions.